### PR TITLE
Improved Timer Display and Management

### DIFF
--- a/src/cppmyth/MythProgramInfo.cpp
+++ b/src/cppmyth/MythProgramInfo.cpp
@@ -268,6 +268,12 @@ std::string MythProgramInfo::ChannelName() const
   return (m_proginfo ? m_proginfo->channel.channelName : "");
 }
 
+std::string MythProgramInfo::Callsign() const
+{
+  return (m_proginfo ? m_proginfo->channel.callSign : "");
+}
+
+
 MythProgramInfo::RecordStatus MythProgramInfo::Status() const
 {
   return (m_proginfo ? (RecordStatus)m_proginfo->recording.status : Myth::RS_UNKNOWN);

--- a/src/cppmyth/MythProgramInfo.h
+++ b/src/cppmyth/MythProgramInfo.h
@@ -71,6 +71,7 @@ public:
   bool HasBookmark() const;
   uint32_t ChannelID() const;
   std::string ChannelName() const;
+  std::string Callsign() const;
   RecordStatus Status() const;
   std::string RecordingGroup() const;
   uint32_t RecordID() const;


### PR DESCRIPTION
Timers created in mythweb / mythfrontend with 'Any Channel' currently show as multiple entries in the Timers list: one entry for each 'repeat' on each channel, most of which are disabled.
**Before:**
![screenshot001](https://cloud.githubusercontent.com/assets/12870817/8144548/9d02fc1c-11db-11e5-99d4-25d42b95a087.png)

This PR hides timers relating to 'earlier', 'later' and 'already in the library' recordings.
Optionally (using client "Show/hide rules with status 'Not Recording'") 'previously recorded but no longer in library' timers can be shown as 'disabled'.

Some bugs preventing the deletion of advanced rules and over-ride (active/inactive) were squashed and 'repeating' attributes were disabled to make the Timers list easier to read.

**After:**
![screenshot000](https://cloud.githubusercontent.com/assets/12870817/8144550/a977d760-11db-11e5-9164-7161cb1de338.png)

**Other benefits:**
_Currently recording_ and _Next recording_ now show what will record and not the disabled alternatives
EPG only shows timer icons for what will actually record, not things which won't.

I believe this makes the Timers screen more usable for helix and Isenguard until proper series recording rule support arrives (hopefully in Jxxxxxx).
