### PR TITLE
Introduce UpdateFromTimer function

### DIFF
--- a/src/cppmyth/MythScheduleHelper75.cpp
+++ b/src/cppmyth/MythScheduleHelper75.cpp
@@ -1117,6 +1117,14 @@ MythRecordingRule MythScheduleHelper75::NewFromTimer(const MythTimerEntry& entry
   return rule;
 }
 
+MythRecordingRule MythScheduleHelper75::UpdateFromTimer(const MythTimerEntry& entry)
+{
+  MythRecordingRule rule;
+  rule.SetType(Myth::RT_UNKNOWN);
+  XBMC->Log(LOG_ERROR, "75::%s: Mythtv 0.26 backend cannot update existing rules using the services API interface.", __FUNCTION__);
+  return rule;
+}
+
 MythRecordingRule MythScheduleHelper75::MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording)
 {
   MythRecordingRule modifier = rule.DuplicateRecordingRule();

--- a/src/cppmyth/MythScheduleHelper75.h
+++ b/src/cppmyth/MythScheduleHelper75.h
@@ -36,6 +36,7 @@ public:
   virtual bool FillTimerEntryWithUpcoming(MythTimerEntry& entry, const MythProgramInfo& recording) const;
   virtual MythRecordingRule NewFromTemplate(const MythEPGInfo& epgInfo);
   virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
+  virtual MythRecordingRule UpdateFromTimer(const MythTimerEntry& entry);
   virtual MythRecordingRule MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording);
   virtual MythRecordingRule MakeOverride(const MythRecordingRule& rule, const MythProgramInfo& recording);
 

--- a/src/cppmyth/MythScheduleHelper76.cpp
+++ b/src/cppmyth/MythScheduleHelper76.cpp
@@ -597,3 +597,49 @@ MythRecordingRule MythScheduleHelper76::NewFromTimer(const MythTimerEntry& entry
           entry.timerType, entry.chanid, entry.callsign.c_str(), (unsigned)entry.startTime, (unsigned)entry.endTime);
   return rule;
 }
+
+bool MythScheduleHelper76::FixRule(MythRecordingRule& rule) const
+{
+  bool ruleIsOK = true;
+  if (rule.StartTime() == rule.EndTime())
+  {
+    rule.SetEndTime(rule.EndTime() + 2);
+    XBMC->Log(LOG_INFO, "%s: Rule %s (%u) has zero duration which the backend would reject. End time increased by 2 seconds.",
+              __FUNCTION__, rule.Title().c_str(), rule.RecordID());
+  }
+  switch (rule.SearchType())
+  {
+    case Myth::ST_PowerSearch:
+      if (rule.Subtitle().empty())
+      {
+        XBMC->Log(LOG_INFO, "%s: Rule %s (%u) has search type PowerSearch with no Subtitle. It will probably do nothing.",
+                  __FUNCTION__, rule.Title().c_str(), rule.RecordID());
+        ruleIsOK = false;
+      }
+    case Myth::ST_TitleSearch:
+    case Myth::ST_KeywordSearch:
+    case Myth::ST_PeopleSearch:
+      if (rule.Description().empty())
+      {
+        XBMC->Log(LOG_INFO, "%s: Rule %s (%u) has search type %u and no Description. It may severly degrade backend performance.",
+                  __FUNCTION__, rule.Title().c_str(), rule.RecordID(), rule.SearchType());
+        ruleIsOK = false;
+      }
+      else if (rule.Description().length() <= 3)
+      {
+        XBMC->Log(LOG_INFO, "%s: Rule %s (%u) has search type %u and a very short Description. It may degrade backend performance.",
+                  __FUNCTION__, rule.Title().c_str(), rule.RecordID(), rule.SearchType());
+        ruleIsOK = false;
+      }
+      break;
+    default:
+      break;
+  }
+  if (rule.ChannelID() == 0 || rule.Callsign() == "")
+  {
+     XBMC->Log(LOG_INFO, "%s: Rule %s (%u) has no associated channel, which the backend will reject.",
+               __FUNCTION__, rule.Title().c_str(), rule.RecordID());
+     ruleIsOK = false;
+  }
+  return ruleIsOK;
+}

--- a/src/cppmyth/MythScheduleHelper76.h
+++ b/src/cppmyth/MythScheduleHelper76.h
@@ -32,4 +32,5 @@ public:
   virtual bool FillTimerEntryWithRule(MythTimerEntry& entry, const MythRecordingRuleNode& node) const;
   //virtual bool FillTimerEntry(MythTimerEntry& entry, const MythProgramInfo& recording) const;
   virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
+  virtual bool FixRule(MythRecordingRule& rule) const;
 };

--- a/src/cppmyth/MythScheduleHelper76.h
+++ b/src/cppmyth/MythScheduleHelper76.h
@@ -33,4 +33,5 @@ public:
   //virtual bool FillTimerEntry(MythTimerEntry& entry, const MythProgramInfo& recording) const;
   virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
   virtual bool FixRule(MythRecordingRule& rule) const;
+  virtual MythRecordingRule UpdateFromTimer(const MythTimerEntry& entry);
 };

--- a/src/cppmyth/MythScheduleHelperNoHelper.cpp
+++ b/src/cppmyth/MythScheduleHelperNoHelper.cpp
@@ -79,6 +79,12 @@ MythRecordingRule MythScheduleHelperNoHelper::NewFromTimer(const MythTimerEntry&
   return MythRecordingRule();
 }
 
+MythRecordingRule MythScheduleHelperNoHelper::UpdateFromTimer(const MythTimerEntry& entry)
+{
+  (void)entry;
+  return MythRecordingRule();
+}
+
 MythRecordingRule MythScheduleHelperNoHelper::MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording)
 {
   MythRecordingRule modifier;

--- a/src/cppmyth/MythScheduleHelperNoHelper.h
+++ b/src/cppmyth/MythScheduleHelperNoHelper.h
@@ -42,6 +42,7 @@ public:
   virtual MythRecordingRule NewFromTemplate(const MythEPGInfo& epgInfo);
   virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
   virtual bool FixRule(MythRecordingRule& rule) const { return false; }
+  virtual MythRecordingRule UpdateFromTimer(const MythTimerEntry& entry);
   virtual MythRecordingRule MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording);
   virtual MythRecordingRule MakeOverride(const MythRecordingRule& rule, const MythProgramInfo& recording);
 

--- a/src/cppmyth/MythScheduleHelperNoHelper.h
+++ b/src/cppmyth/MythScheduleHelperNoHelper.h
@@ -41,6 +41,7 @@ public:
   virtual bool FillTimerEntryWithUpcoming(MythTimerEntry& entry, const MythProgramInfo& recording) const;
   virtual MythRecordingRule NewFromTemplate(const MythEPGInfo& epgInfo);
   virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
+  virtual bool FixRule(MythRecordingRule& rule) const { return false; }
   virtual MythRecordingRule MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording);
   virtual MythRecordingRule MakeOverride(const MythRecordingRule& rule, const MythProgramInfo& recording);
 

--- a/src/cppmyth/MythScheduleManager.cpp
+++ b/src/cppmyth/MythScheduleManager.cpp
@@ -962,6 +962,12 @@ MythRecordingRule MythScheduleManager::NewFromTimer(const MythTimerEntry& entry,
   return m_versionHelper->NewFromTimer(entry, withTemplate);
 }
 
+bool MythScheduleManager::FixRule(MythRecordingRule& rule) const
+{
+  CLockObject lock(m_lock);
+  return m_versionHelper->FixRule(rule);
+}
+
 MythRecordingRuleList MythScheduleManager::GetTemplateRules() const
 {
   CLockObject lock(m_lock);

--- a/src/cppmyth/MythScheduleManager.cpp
+++ b/src/cppmyth/MythScheduleManager.cpp
@@ -263,7 +263,7 @@ MythScheduleManager::MSM_ERROR MythScheduleManager::UpdateTimer(const MythTimerE
     case TIMER_TYPE_DONT_RECORD:
     case TIMER_TYPE_OVERRIDE:
     {
-      MythRecordingRule newrule = m_versionHelper->NewFromTimer(entry, false);
+      MythRecordingRule newrule = m_versionHelper->UpdateFromTimer(entry);
       return UpdateRecording(entry.entryIndex, newrule);
     }
     case TIMER_TYPE_MANUAL_SEARCH:
@@ -276,12 +276,7 @@ MythScheduleManager::MSM_ERROR MythScheduleManager::UpdateTimer(const MythTimerE
     case TIMER_TYPE_SEARCH_KEYWORD:
     case TIMER_TYPE_SEARCH_PEOPLE:
     {
-      if (entry.epgCheck && entry.epgInfo.IsNull())
-      {
-        XBMC->Log(LOG_ERROR, "%s: index %u requires valid EPG info", __FUNCTION__, entry.entryIndex);
-        return MSM_ERROR_NOT_IMPLEMENTED;
-      }
-      MythRecordingRule newrule = m_versionHelper->NewFromTimer(entry, false);
+      MythRecordingRule newrule = m_versionHelper->UpdateFromTimer(entry);
       return UpdateRecordingRule(entry.entryIndex, newrule);
     }
     default:
@@ -966,6 +961,12 @@ bool MythScheduleManager::FixRule(MythRecordingRule& rule) const
 {
   CLockObject lock(m_lock);
   return m_versionHelper->FixRule(rule);
+}
+
+MythRecordingRule MythScheduleManager::UpdateFromTimer(const MythTimerEntry& entry)
+{
+  CLockObject lock(m_lock);
+  return m_versionHelper->UpdateFromTimer(entry);
 }
 
 MythRecordingRuleList MythScheduleManager::GetTemplateRules() const

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -169,6 +169,7 @@ public:
   bool FillTimerEntryWithRule(MythTimerEntry& entry, const MythRecordingRuleNode& node) const;
   bool FillTimerEntryWithUpcoming(MythTimerEntry& entry, const MythProgramInfo& recording) const;
   MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
+  bool FixRule(MythRecordingRule& rule) const;
 
   MythRecordingRuleList GetTemplateRules() const;
 
@@ -188,6 +189,7 @@ public:
     virtual bool FillTimerEntryWithUpcoming(MythTimerEntry& entry, const MythProgramInfo& recording) const = 0;
     virtual MythRecordingRule NewFromTemplate(const MythEPGInfo& epgInfo) = 0;
     virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate) = 0;
+    virtual bool FixRule(MythRecordingRule& rule) const = 0;
     virtual MythRecordingRule MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording) = 0;
     virtual MythRecordingRule MakeOverride(const MythRecordingRule& rule, const MythProgramInfo& recording) = 0;
   };

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -170,6 +170,7 @@ public:
   bool FillTimerEntryWithUpcoming(MythTimerEntry& entry, const MythProgramInfo& recording) const;
   MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate);
   bool FixRule(MythRecordingRule& rule) const;
+  MythRecordingRule UpdateFromTimer(const MythTimerEntry& entry);
 
   MythRecordingRuleList GetTemplateRules() const;
 
@@ -190,6 +191,7 @@ public:
     virtual MythRecordingRule NewFromTemplate(const MythEPGInfo& epgInfo) = 0;
     virtual MythRecordingRule NewFromTimer(const MythTimerEntry& entry, bool withTemplate) = 0;
     virtual bool FixRule(MythRecordingRule& rule) const = 0;
+    virtual MythRecordingRule UpdateFromTimer(const MythTimerEntry& entry) = 0;
     virtual MythRecordingRule MakeDontRecord(const MythRecordingRule& rule, const MythProgramInfo& recording) = 0;
     virtual MythRecordingRule MakeOverride(const MythRecordingRule& rule, const MythProgramInfo& recording) = 0;
   };


### PR DESCRIPTION
@janbar This introduces only the new function as you requested.
Now it will only modify settings allowed by MythScheduleManager::UpdateRecordingRule

The code can also change other settings (selected channel, 'any channel', 'any time', search type, rule type etc...), but other parts of code need fixing first (see Part 1 and Part 2 of my proposed changes).
You will get extra debug statements showing you what would have changed.

If you like this, I will prepare these fixes/changes, one commit for each setting I enable.

To really work properly I also need to do parts 1, 2, 6 and part of 4 (without the API 3.0.0 change). (see http://forum.kodi.tv/showthread.php?tid=230145&pid=2074228#pid2074228 )
