### PR TITLE
Tidyup in preparation for API3.0.0 changes

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -46,8 +46,6 @@
 #define DEFAULT_RECORDING_ICONS             true
 #define DEFAULT_RECORD_TEMPLATE             1
 
-#define SUBTITLE_SEPARATOR                  " - "
-
 #define MENUHOOK_REC_DELETE_AND_RERECORD    1
 #define MENUHOOK_KEEP_LIVETV_RECORDING      2
 #define MENUHOOK_TIMER_BACKEND_INFO         3

--- a/src/cppmyth/MythScheduleHelper75.cpp
+++ b/src/cppmyth/MythScheduleHelper75.cpp
@@ -650,7 +650,7 @@ bool MythScheduleHelper75::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
   entry.endTime = recording.EndTime();
   entry.title.assign(recording.Title());
   if (!recording.Subtitle().empty())
-    entry.title.append(" - ").append(recording.Subtitle());
+    entry.title.append(" (").append(recording.Subtitle()).append(")");
   if (recording.Season() || recording.Episode())
     entry.title.append(" - ").append(Myth::IntToString(recording.Season())).append(".").append(Myth::IntToString(recording.Episode()));
   entry.recordingGroup = GetRuleRecordingGroupId(recording.RecordingGroup());

--- a/src/cppmyth/MythScheduleHelper85.cpp
+++ b/src/cppmyth/MythScheduleHelper85.cpp
@@ -106,7 +106,7 @@ bool MythScheduleHelper85::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
   entry.endTime = recording.EndTime();
   entry.title.assign(recording.Title());
   if (!recording.Subtitle().empty())
-    entry.title.append(" - ").append(recording.Subtitle());
+    entry.title.append(" (").append(recording.Subtitle()).append(")");
   if (recording.Season() || recording.Episode())
     entry.title.append(" - ").append(Myth::IntToString(recording.Season())).append(".").append(Myth::IntToString(recording.Episode()));
   entry.recordingGroup = GetRuleRecordingGroupId(recording.RecordingGroup());

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -77,10 +77,22 @@ struct MythTimerEntry
   uint32_t      parentIndex;
   Myth::RS_t    recordingStatus;
   MythTimerEntry()
-  : isInactive(false), timerType(TIMER_TYPE_UNHANDLED), epgCheck(false)
-  , chanid(0), startTime(0), endTime(0), startOffset(0), endOffset(0), priority(0)
-  , dupMethod(Myth::DM_CheckNone), expiration(0), firstShowing(false), recordingGroup(0)
-  , entryIndex(0), parentIndex(0), recordingStatus(Myth::RS_UNKNOWN) { }
+  : isInactive(false)
+  , timerType(TIMER_TYPE_UNHANDLED)
+  , epgCheck(false)
+  , chanid(0)
+  , startTime(0)
+  , endTime(0)
+  , startOffset(0)
+  , endOffset(0)
+  , priority(0)
+  , dupMethod(Myth::DM_CheckNone)
+  , expiration(0)
+  , firstShowing(false)
+  , recordingGroup(0)
+  , entryIndex(0)
+  , parentIndex(0)
+  , recordingStatus(Myth::RS_UNKNOWN) { }
   bool HasChannel() const { return (chanid > 0 && !callsign.empty() ? true : false); }
   bool HasTimeSlot() const { return (startTime > 0 && endTime >= startTime ? true : false); }
 };

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -522,8 +522,7 @@ PVR_ERROR PVRClientMythTV::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANN
       // EPG_TAG expects strings as char* and not as copies (like the other PVR types).
       // Therefore we have to make sure that we don't pass invalid (freed) memory to TransferEpgEntry.
       // In particular we have to use local variables and must not pass returned string values directly.
-      std::string epgTitle = MakeProgramTitle(it->second->title, it->second->subTitle);
-      tag.strTitle = epgTitle.c_str();
+      tag.strTitle = it->second->title.c_str();
       tag.strPlot = it->second->description.c_str();
       tag.strGenreDescription = it->second->category.c_str();
       tag.iUniqueBroadcastId = MythEPGInfo::MakeBroadcastID(it->second->channel.chanId, it->first);
@@ -531,7 +530,7 @@ PVR_ERROR PVRClientMythTV::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANN
       int genre = m_categories.Category(it->second->category);
       tag.iGenreSubType = genre & 0x0F;
       tag.iGenreType = genre & 0xF0;
-      tag.strEpisodeName = "";
+      tag.strEpisodeName = it->second->subTitle.c_str();
       tag.strIconPath = "";
       tag.strPlotOutline = "";
       tag.bNotify = false;
@@ -2521,7 +2520,7 @@ std::string PVRClientMythTV::MakeProgramTitle(const std::string& title, const st
   if (subtitle.empty())
     epgtitle = title;
   else
-    epgtitle = title + SUBTITLE_SEPARATOR + subtitle;
+    epgtitle = title + " (" + subtitle + ")";
   return epgtitle;
 }
 


### PR DESCRIPTION
Re-formats the MythTimerEntry defaults, so adding extra fields (if necessary in future) will be less likely to cause merge conflicts.

Other change removed as supply_subtitle_as_confluence does what I wanted to propose
