### PR TITLE
Limit Channel Change Attempts

### DIFF
--- a/lib/cppmyth/src/mythlivetvplayback.cpp
+++ b/lib/cppmyth/src/mythlivetvplayback.cpp
@@ -122,6 +122,12 @@ void LiveTVPlayback::Close()
   ProtoMonitor::Close();
 }
 
+void LiveTVPlayback::SetLimitChannelChange(bool limitchannelchange)
+{
+  
+    m_limitChannelChange = limitchannelchange;
+}
+
 void LiveTVPlayback::SetTuneDelay(unsigned delay)
 {
   if (delay < MIN_TUNE_DELAY)
@@ -176,6 +182,12 @@ bool LiveTVPlayback::SpawnLiveTV(const std::string& chanNum, const ChannelList& 
       m_recorder->StopLiveTV();
     }
     ClearChain();
+    // check if we need to stop after first attempt at tuning
+    if (m_limitChannelChange)
+    {
+      DBG(MYTH_DBG_DEBUG, "%s: Limiting Channel Change Attempts to 1\n", __FUNCTION__);
+      break;
+    }
     // Retry the next preferred card
     ++card;
   }

--- a/lib/cppmyth/src/mythlivetvplayback.h
+++ b/lib/cppmyth/src/mythlivetvplayback.h
@@ -45,6 +45,7 @@ namespace Myth
     void Close();
     bool IsOpen() { return ProtoMonitor::IsOpen(); }
     void SetTuneDelay(unsigned delay);
+    void SetLimitChannelChange (bool limitchannelchange);
     bool SpawnLiveTV(const std::string& chanNum, const ChannelList& channels);
     bool SpawnLiveTV(const ChannelPtr& thisChannel);
     void StopLiveTV();
@@ -73,6 +74,7 @@ namespace Myth
     unsigned m_eventSubscriberId;
 
     unsigned m_tuneDelay;
+    bool m_limitChannelChange;
     ProtoRecorderPtr m_recorder;
     SignalStatusPtr m_signal;
 

--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -201,7 +201,11 @@ msgctxt "#30064"
 msgid "Enable recording fanart/thumbnails"
 msgstr ""
 
-#empty strings from id 30065 to 30099
+msgctxt "#30065"
+msgid "Limit channel change attempts"
+msgstr ""
+
+#empty strings from id 30066 to 30099
 
 # Systeminformation labels
 msgctxt "#30100"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -32,5 +32,6 @@
     <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />
+    <setting id="limitchannelchange" type="bool" label="30065" default="false" />
   </category>
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -57,6 +57,7 @@ int           g_iTuneDelay              = DEFAULT_TUNE_DELAY;
 int           g_iGroupRecordings        = GROUP_RECORDINGS_ALWAYS;
 int           g_iEnableEDL              = ENABLE_EDL_ALWAYS;
 bool          g_bBlockMythShutdown      = DEFAULT_BLOCK_SHUTDOWN;
+bool          g_bLimitChannelChange     = DEFAULT_LIMIT_CHANNEL_CHANGE;
 
 ///* Client member variables */
 ADDON_STATUS  m_CurStatus               = ADDON_STATUS_UNKNOWN;
@@ -190,6 +191,14 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'extradebug' setting, falling back to '%b' as default", DEFAULT_EXTRA_DEBUG);
     g_bExtraDebug = DEFAULT_EXTRA_DEBUG;
+  }
+
+  /* Read setting "limitchannelchange" from settings.xml */
+  if (!XBMC->GetSetting("limitchannelchange", &g_bLimitChannelChange))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'limitchannelchnge' setting, falling back to '%b' as default", DEFAULT_LIMIT_CHANNEL_CHANGE);
+    g_bLimitChannelChange = DEFAULT_LIMIT_CHANNEL_CHANGE;
   }
 
   /* Read setting "LiveTV" from settings.xml */
@@ -583,6 +592,12 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     XBMC->Log(LOG_INFO, "Changed Setting 'rec_autoexpire' from %u to %u", g_bRecAutoExpire, *(bool*)settingValue);
     if (g_bRecAutoExpire != *(bool*)settingValue)
       g_bRecAutoExpire = *(bool*)settingValue;
+  }
+  else if (str == "limitchannelchange")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'limitchannelchange' from %u to %u", g_bLimitChannelChange, *(bool*)settingValue);
+    if (g_bLimitChannelChange != *(bool*)settingValue)
+      g_bLimitChannelChange = *(bool*)settingValue;
   }
   else if (str == "tunedelay")
   {

--- a/src/client.h
+++ b/src/client.h
@@ -62,7 +62,7 @@
 #define ENABLE_EDL_DIALOG                   1
 #define ENABLE_EDL_NEVER                    2
 #define DEFAULT_BLOCK_SHUTDOWN              true
-
+#define DEFAULT_LIMIT_CHANNEL_CHANGE        false
 /*!
  * @brief PVR macros for string exchange
  */
@@ -91,6 +91,7 @@ extern int          g_iLiveTVConflictStrategy;  ///< Live TV conflict resolving 
 extern bool         g_bChannelIcons;            ///< Load Channel Icons
 extern bool         g_bRecordingIcons;          ///< Load Recording Icons (Fanart/Thumbnails)
 extern int          g_iRecTemplateType;         ///< Template type for new record (0=Internal, 1=MythTV)
+extern bool         g_bLimitChannelChange;      ///< Limit Channel Change Atttempts
 ///* Internal Record template */
 extern bool         g_bRecAutoMetadata;
 extern bool         g_bRecAutoCommFlag;

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -1948,6 +1948,8 @@ bool PVRClientMythTV::OpenLiveStream(const PVR_CHANNEL &channel)
     m_fileOps->Suspend();
   // Set tuning delay
   m_liveStream->SetTuneDelay(g_iTuneDelay);
+  // Set limit channel change
+  m_liveStream->SetLimitChannelChange(g_bLimitChannelChange);
   // Try to open
   if (m_liveStream->SpawnLiveTV(chanset[0]->chanNum, chanset))
   {


### PR DESCRIPTION
@janbar 

I have had a go at limiting channel change attempts - I am not a coder.
There is a new option in the Advanced tab of pvr.mythtv to Limit channel change attempts so that channel unavailable message appears in kodi faster as only one channel change is attempted.

I don't know how the language translation strings are done.

Let me know what you think

Mike
