### PR TITLE
PVR API 3.0.0 + recording season/episode + scraper support

### DIFF
--- a/src/cppmyth/MythProgramInfo.cpp
+++ b/src/cppmyth/MythProgramInfo.cpp
@@ -328,3 +328,8 @@ uint16_t MythProgramInfo::Episode() const
 {
   return (m_proginfo ? m_proginfo->episode : 0);
 }
+
+time_t MythProgramInfo::Airdate() const
+{
+  return (m_proginfo ? m_proginfo->airdate : 0);
+}

--- a/src/cppmyth/MythProgramInfo.h
+++ b/src/cppmyth/MythProgramInfo.h
@@ -82,6 +82,7 @@ public:
   std::string Inetref() const;
   uint16_t Season() const;
   uint16_t Episode() const;
+  time_t Airdate() const;
 
 private:
   Myth::ProgramPtr m_proginfo;

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -847,10 +847,19 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
       //@TODO: tag.iLastPlayedPosition
 
       std::string id = it->second.UID();
-      std::string title = MakeProgramTitle(it->second.Title(), it->second.Subtitle());
 
       PVR_STRCPY(tag.strRecordingId, id.c_str());
-      PVR_STRCPY(tag.strTitle, title.c_str());
+      PVR_STRCPY(tag.strTitle, it->second.Title().c_str());
+      PVR_STRCPY(tag.strEpisodeName, it->second.Subtitle().c_str());
+      tag.iSeriesNumber = it->second.Season();
+      tag.iEpisodeNumber = it->second.Episode();
+      time_t airTime(it->second.Airdate());
+      if (difftime(airTime, 0) > 0)
+      {
+        struct tm airTimeDate;
+        localtime_r(&airTime, &airTimeDate);
+        tag.iYear = airTimeDate.tm_year + 1900;
+      }
       PVR_STRCPY(tag.strPlot, it->second.Description().c_str());
       PVR_STRCPY(tag.strChannelName, it->second.ChannelName().c_str());
 
@@ -949,10 +958,19 @@ PVR_ERROR PVRClientMythTV::GetDeletedRecordings(ADDON_HANDLE handle)
       //@TODO: tag.iLastPlayedPosition
 
       std::string id = it->second.UID();
-      std::string title = MakeProgramTitle(it->second.Title(), it->second.Subtitle());
 
       PVR_STRCPY(tag.strRecordingId, id.c_str());
-      PVR_STRCPY(tag.strTitle, title.c_str());
+      PVR_STRCPY(tag.strTitle, it->second.Title().c_str());
+      PVR_STRCPY(tag.strEpisodeName, it->second.Subtitle().c_str());
+      tag.iSeriesNumber = it->second.Season();
+      tag.iEpisodeNumber = it->second.Episode();
+      time_t airTime(it->second.Airdate());
+      if (difftime(airTime, 0) > 0)
+      {
+        struct tm airTimeDate;
+        localtime_r(&airTime, &airTimeDate);
+        tag.iYear = airTimeDate.tm_year + 1900;
+      }
       PVR_STRCPY(tag.strPlot, it->second.Description().c_str());
       PVR_STRCPY(tag.strChannelName, it->second.ChannelName().c_str());
 


### PR DESCRIPTION
@janbar This is a PR for PVR API3.0.0, the minimal changes which were just merged into the main pvr.mythtv repository and an implementation which supplies the following extra fields for recordings:
1. Episode Name (Subititle)
2. Season
3. Episode
4. Original Air Date
