### PR TITLE
Epg association (Recordings)

### DIFF
--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -832,6 +832,7 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
       }
     }
   }
+  time_t now = time(NULL);
   // Transfer to PVR
   for (ProgramInfoMap::iterator it = m_recordings.begin(); it != m_recordings.end(); ++it)
   {
@@ -895,6 +896,10 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
       PVR_STRCPY(tag.strIconPath, strIconPath.c_str());
       PVR_STRCPY(tag.strThumbnailPath, strIconPath.c_str());
       PVR_STRCPY(tag.strFanartPath, strFanartPath.c_str());
+
+      // EPG Entry (Enables "Play recording" option and icon)
+      if (difftime(now, it->second.EndTime()) < 60 * 60 * 24 ) // Up to 1 day in the past
+        tag.iEpgEventId = MythEPGInfo::MakeBroadcastID(FindPVRChannelUid(it->second.ChannelID()), it->second.StartTime());
 
       // Unimplemented
       tag.iLifetime = 0;


### PR DESCRIPTION
Two commits to fix EPG associations for Timers and add EPG associations for Recordings
1) Timers now show an icon for everything that will will be recorded in the EPG view
![screenshot023](https://cloud.githubusercontent.com/assets/12870817/9530903/8b5e32d8-4cfa-11e5-8741-d4fb57330fc8.png)
2) Recordings now show a 'play' icon and 'Play Recording' menu option in the EPG view
![screenshot022](https://cloud.githubusercontent.com/assets/12870817/9530902/8b590006-4cfa-11e5-8c45-7cdcb1965136.png)
