### PR TITLE
Add subtitle/season/episode to Timer display (single shot types)

### DIFF
--- a/lib/cppmyth/src/private/mythdto/mythdto75.h
+++ b/lib/cppmyth/src/private/mythdto/mythdto75.h
@@ -142,7 +142,7 @@ namespace MythDTO75
     { "ParentId",         IS_UINT32,  (setter_t)MythDTO::SetSchedule_ParentId },
     { "Inactive",         IS_BOOLEAN, (setter_t)MythDTO::SetSchedule_Inactive },
     { "Title",            IS_STRING,  (setter_t)MythDTO::SetSchedule_Title },
-    { "Subtitle",         IS_STRING,  (setter_t)MythDTO::SetSchedule_Subtitle },
+    { "SubTitle",         IS_STRING,  (setter_t)MythDTO::SetSchedule_Subtitle },
     { "Description",      IS_STRING,  (setter_t)MythDTO::SetSchedule_Description },
     { "Season",           IS_UINT16,  (setter_t)MythDTO::SetSchedule_Season },
     { "Episode",          IS_UINT16,  (setter_t)MythDTO::SetSchedule_Episode },

--- a/lib/cppmyth/src/private/mythdto/mythdto76.h
+++ b/lib/cppmyth/src/private/mythdto/mythdto76.h
@@ -41,7 +41,7 @@ namespace MythDTO76
     { "ParentId",         IS_UINT32,  (setter_t)MythDTO::SetSchedule_ParentId },
     { "Inactive",         IS_BOOLEAN, (setter_t)MythDTO::SetSchedule_Inactive },
     { "Title",            IS_STRING,  (setter_t)MythDTO::SetSchedule_Title },
-    { "Subtitle",         IS_STRING,  (setter_t)MythDTO::SetSchedule_Subtitle },
+    { "SubTitle",         IS_STRING,  (setter_t)MythDTO::SetSchedule_Subtitle },
     { "Description",      IS_STRING,  (setter_t)MythDTO::SetSchedule_Description },
     { "Season",           IS_UINT16,  (setter_t)MythDTO::SetSchedule_Season },
     { "Episode",          IS_UINT16,  (setter_t)MythDTO::SetSchedule_Episode },

--- a/src/cppmyth/MythScheduleHelper75.cpp
+++ b/src/cppmyth/MythScheduleHelper75.cpp
@@ -658,8 +658,10 @@ bool MythScheduleHelper75::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
   entry.title.assign(recording.Title());
   if (!recording.Subtitle().empty())
     entry.title.append(" (").append(recording.Subtitle()).append(")");
-  if (recording.Season() || recording.Episode())
+  if (recording.Season() && recording.Episode())
     entry.title.append(" - ").append(Myth::IntToString(recording.Season())).append(".").append(Myth::IntToString(recording.Episode()));
+  else if (recording.Episode())
+    entry.title.append(" - S").append(Myth::IntToString(recording.Episode()));
   entry.recordingGroup = GetRuleRecordingGroupId(recording.RecordingGroup());
   entry.entryIndex = MythScheduleManager::MakeIndex(recording); // upcoming index
   return true;


### PR DESCRIPTION
This PR adds 'Subtitle' to the end of single shot timers (Manual/This/One) where it exists in the rule.
A fix for cppmyth is included as a separate commit (SubTitle not Subtitle)
Where data for Season/Episode is also available, this is also added.
The format for Season/Episode display is changed to match Kodi default for 'Specials'
(Season/Episode display not tested here as my 0.27 backend doesn't provide it for timers)

![screenshot024](https://cloud.githubusercontent.com/assets/12870817/9555080/c867a542-4dc2-11e5-9d40-53fc91aae3e3.png)

ping @janbar
