### PR TITLE
Disable create of 'RecordSeries' unless seriesid is set

### DIFF
--- a/src/cppmyth/MythScheduleHelper75.cpp
+++ b/src/cppmyth/MythScheduleHelper75.cpp
@@ -174,7 +174,7 @@ MythTimerTypeList MythScheduleHelper75::GetTimerTypes() const
 
     m_timerTypeList.push_back(MythTimerTypePtr(new MythTimerType(TIMER_TYPE_RECORD_SERIES,
             PVR_TIMER_TYPE_IS_REPEATING |
-            PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
+            PVR_TIMER_TYPE_REQUIRES_EPG_SERIES_ON_CREATE |
             PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
             PVR_TIMER_TYPE_SUPPORTS_RECORD_ONLY_NEW_EPISODES |
             PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -562,7 +562,10 @@ PVR_ERROR PVRClientMythTV::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANN
       tag.strWriter = "";
       tag.iYear = 0;
       tag.strIMDBNumber = it->second->inetref.c_str();
-      tag.iFlags = EPG_TAG_FLAG_UNDEFINED;
+      if (!it->second->seriesId.empty())
+        tag.iFlags = EPG_TAG_FLAG_IS_SERIES;
+      else
+        tag.iFlags = EPG_TAG_FLAG_UNDEFINED;
 
       PVR->TransferEpgEntry(handle, &tag);
     }


### PR DESCRIPTION
This makes use of the new API 4.1.0 PVR_TIMER_TYPE_REQUIRES_SERIES_ON_CREATE flag to prevent a user creating a new 'Record series' custom timer if the EPG entry selected does not have a seriesid in the mythtv database.
Should stop users creating 'Record series' timers which do nothing because their EPG source doesn't include seriesid information.

With a series ID (or season/episode/part != 0, see below):
![screenshot029](https://cloud.githubusercontent.com/assets/12870817/10022650/dcf6d708-6145-11e5-9515-b57e6a22ca1c.png)

Without a seriesID:
![screenshot030](https://cloud.githubusercontent.com/assets/12870817/10022656/e6d775fc-6145-11e5-99ef-eee7256315f2.png)

To use the feature immediately, clear the EPG database so Kodi core refreshes EPG 'series' information from the backend. 'Record series' will then appear as an option for recordings with a seriesid.

Actually, kodi core will also enable 'Record series' if 'season/episode/episode part' are non-zero and IS_SERIES is reset, but it is highly likely there will be a serisid in the database as well if one of these is non-zero.
