### PR TITLE
Add configuration to allow EPG/Timers to be disabled.

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -205,7 +205,15 @@ msgctxt "#30065"
 msgid "Limit channel tuning attempts"
 msgstr ""
 
-# empty strings from id 30066 to 30099
+msgctxt "#30066"
+msgid "Enable EPG (requires restart)"
+msgstr "Enable EPG (requires restart)"
+
+msgctxt "#30067"
+msgid "Enable timers (requires restart)"
+msgstr "Enable timers (requires restart)"
+
+# empty strings from id 30068 to 30099
 
 # Systeminformation labels
 msgctxt "#30100"

--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -206,12 +206,12 @@ msgid "Limit channel tuning attempts"
 msgstr ""
 
 msgctxt "#30066"
-msgid "Enable EPG (requires restart)"
-msgstr "Enable EPG (requires restart)"
+msgid "Enable EPG"
+msgstr "Enable EPG"
 
 msgctxt "#30067"
-msgid "Enable timers (requires restart)"
-msgstr "Enable timers (requires restart)"
+msgid "Enable timers"
+msgstr "Enable timers"
 
 # empty strings from id 30068 to 30099
 

--- a/pvr.mythtv/resources/language/resource.language.en_us/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_us/strings.po
@@ -196,6 +196,14 @@ msgctxt "#30065"
 msgid "Limit channel tuning attempts"
 msgstr "Limit channel tuning attempts"
 
+msgctxt "#30066"
+msgid "Enable EPG (requires restart)"
+msgstr "Enable EPG (requires restart)"
+
+msgctxt "#30067"
+msgid "Enable timers (requires restart)"
+msgstr "Enable timers (requires restart)"
+
 msgctxt "#30100"
 msgid "Protocol version: %i - Database version: %i"
 msgstr "Protocol version: %i - Database version: %i"

--- a/pvr.mythtv/resources/language/resource.language.en_us/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_us/strings.po
@@ -197,12 +197,12 @@ msgid "Limit channel tuning attempts"
 msgstr "Limit channel tuning attempts"
 
 msgctxt "#30066"
-msgid "Enable EPG (requires restart)"
-msgstr "Enable EPG (requires restart)"
+msgid "Enable EPG"
+msgstr "Enable EPG"
 
 msgctxt "#30067"
-msgid "Enable timers (requires restart)"
-msgstr "Enable timers (requires restart)"
+msgid "Enable timers"
+msgstr "Enable timers"
 
 msgctxt "#30100"
 msgid "Protocol version: %i - Database version: %i"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -9,6 +9,8 @@
     <setting id="livetv" type="bool" label="30006" default="true" />
     <setting id="livetv_priority" type="bool" label="30007" default="true" />
     <setting id="livetv_conflict_strategy" type="enum" label="30008" lvalues="30009|30010|30011" default="0" />
+    <setting id="epg" type="bool" label="30066" default="true" />
+    <setting id="timers" type="bool" label="30067" default="true" />
   </category>
   <category label="30049">
     <setting id="rec_template_provider" type="enum" label="30020" lvalues="30021|30022" default="1" />
@@ -33,7 +35,5 @@
     <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />
-    <setting id="epg" type="bool" label="30066" default="true" />
-    <setting id="timers" type="bool" label="30067" default="true" />
   </category>
 </settings>

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -33,5 +33,7 @@
     <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />
+    <setting id="epg" type="bool" label="30066" default="true" />
+    <setting id="timers" type="bool" label="30067" default="true" />
   </category>
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -40,6 +40,8 @@ int           g_iWSApiPort              = DEFAULT_WSAPI_PORT;               ///<
 std::string   g_szWSSecurityPin         = DEFAULT_WSAPI_SECURITY_PIN;       ///< The default security pin for the mythtv wsapi
 bool          g_bExtraDebug             = DEFAULT_EXTRA_DEBUG;              ///< Output extensive debug information to the log
 bool          g_bLiveTV                 = DEFAULT_LIVETV;                   ///< LiveTV support (or recordings only)
+bool          g_bEPG                    = DEFAULT_EPG;                      ///< EPG support
+bool          g_bTimers                 = DEFAULT_TIMERS;                   ///< Timers support
 bool          g_bLiveTVPriority         = DEFAULT_LIVETV_PRIORITY;          ///< MythTV Backend setting to allow live TV to move scheduled shows
 int           g_iLiveTVConflictStrategy = DEFAULT_LIVETV_CONFLICT_STRATEGY; ///< Conflict resolving strategy (0=
 bool          g_bChannelIcons           = DEFAULT_CHANNEL_ICONS;            ///< Load Channel Icons
@@ -202,7 +204,18 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     XBMC->Log(LOG_ERROR, "Couldn't get 'livetv' setting, falling back to '%b' as default", DEFAULT_LIVETV);
     g_bLiveTV = DEFAULT_LIVETV;
   }
-
+  if (!XBMC->GetSetting("epg", &g_bEPG))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'epg' setting, falling back to '%u' as default", DEFAULT_EPG);
+    g_bEPG = DEFAULT_EPG;
+  }
+  if (!XBMC->GetSetting("timers", &g_bTimers))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'timers' setting, falling back to '%u' as default", DEFAULT_TIMERS);
+    g_bTimers = DEFAULT_TIMERS;
+  }
   /* Read settings "Record livetv_conflict_method" from settings.xml */
   if (!XBMC->GetSetting("livetv_conflict_strategy", &g_iLiveTVConflictStrategy))
   {
@@ -569,6 +582,18 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     if (g_bLiveTV != *(bool*)settingValue)
       g_bLiveTV = *(bool*)settingValue;
   }
+  else if (str == "epg")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'epg' from %u to %u", g_bEPG, *(bool*)settingValue);
+    if (g_bEPG != *(bool*)settingValue)
+      g_bEPG = *(bool*)settingValue;
+  }
+  else if (str == "timers")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'timers' from %u to %u", g_bTimers, *(bool*)settingValue);
+    if (g_bTimers != *(bool*)settingValue)
+      g_bTimers = *(bool*)settingValue;
+  }
   else if (str == "livetv_priority")
   {
     XBMC->Log(LOG_INFO, "Changed Setting 'extra debug' from %u to %u", g_bLiveTVPriority, *(bool*)settingValue);
@@ -727,8 +752,8 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities)
     pCapabilities->bSupportsRadio                 = g_bLiveTV;
     pCapabilities->bSupportsChannelGroups         = true;
     pCapabilities->bSupportsChannelScan           = false;
-    pCapabilities->bSupportsEPG                   = true;
-    pCapabilities->bSupportsTimers                = true;
+    pCapabilities->bSupportsEPG                   = g_bEPG;
+    pCapabilities->bSupportsTimers                = g_bTimers;
 
     pCapabilities->bHandlesInputStream            = true;
     pCapabilities->bHandlesDemuxing               = g_bDemuxing;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -586,13 +586,17 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   {
     XBMC->Log(LOG_INFO, "Changed Setting 'epg' from %u to %u", g_bEPG, *(bool*)settingValue);
     if (g_bEPG != *(bool*)settingValue)
-      g_bEPG = *(bool*)settingValue;
+    {
+      return ADDON_STATUS_NEED_RESTART;
+    }
   }
   else if (str == "timers")
   {
     XBMC->Log(LOG_INFO, "Changed Setting 'timers' from %u to %u", g_bTimers, *(bool*)settingValue);
     if (g_bTimers != *(bool*)settingValue)
-      g_bTimers = *(bool*)settingValue;
+    {
+      return ADDON_STATUS_NEED_RESTART;
+    }
   }
   else if (str == "livetv_priority")
   {

--- a/src/client.h
+++ b/src/client.h
@@ -39,6 +39,8 @@
 #define DEFAULT_LIVETV_PRIORITY             true
 #define DEFAULT_LIVETV_CONFLICT_STRATEGY    LIVETV_CONFLICT_STRATEGY_HASLATER
 #define DEFAULT_LIVETV                      true
+#define DEFAULT_EPG                         true
+#define DEFAULT_TIMERS                      true
 #define DEFAULT_PROTO_PORT                  6543
 #define DEFAULT_WSAPI_PORT                  6544
 #define DEFAULT_WSAPI_SECURITY_PIN          "0000"


### PR DESCRIPTION
With the growing number of cheap, low-memory, low-power Android
devices, it means one user can have several Kodi devices. Most of
these will never be used for scheduling so allow it to be optionally
disabled.

This is also useful for people that only use mythweb/mythfrontend
for scheduling or use Kodi occasionally.

You can still access live tv even with EPG and timers disabled
such as via the channels menu item.

The new options are in the advanced settings "enable EPG" and
"enable timers". Both require a restart of Kodi to take effect.

By default, most skins will still show the EPG and timers menu
items even if they are disabled.

After disabling the EPG, the EPG menu item will still contain data
until it is expired.
