### PR TITLE
Prevent initial connect event refreshing recordings

### DIFF
--- a/src/pvrclient-mythtv.h
+++ b/src/pvrclient-mythtv.h
@@ -159,6 +159,10 @@ private:
   FileStreaming *m_dummyStream;
   bool m_hang;
   bool m_powerSaving;
+  bool m_InitConnectReceived;
+  bool m_InitChannelsInvalid;
+  bool m_InitScheduleInvalid;
+  bool m_InitRecordingsInvalid;
 
   // Backend
   FileOps *m_fileOps;


### PR DESCRIPTION
I've recently switched to a pi2 mythtv primary backend and added some extra storage...
This means I now have more recordings (1038 at the moment) and found my frontend was spending a _very_ long time in the 'Loading recordings from clients' phase.

On investigating, I found that the recordings were being loaded twice: Once requested by kodi PVR core on initial connection and once as a result of the backend announcing a 'connected' event.

This PR adds a boolean to avoid an initial connection event causing a refresh when the pvr.mythtv client is first started.

The 'Loading recordings from clients' phase on initial startup now takes ~20 seconds instead of 40.
