### PR TITLE
Inactive upcomings

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -341,7 +341,17 @@ msgctxt "#30456"
 msgid "Zombie"
 msgstr ""
 
-# empty strings from id 30457 to 30459
+msgctxt "#30457"
+msgid "Alternative"
+msgstr ""
+
+msgctxt "#30458"
+msgid "Currently recorded"
+msgstr ""
+
+msgctxt "#30459"
+msgid "Expired recording"
+msgstr ""
 
 msgctxt "#30460"
 msgid "Manual"

--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -205,7 +205,11 @@ msgctxt "#30065"
 msgid "Limit channel tuning attempts"
 msgstr ""
 
-# empty strings from id 30066 to 30099
+msgctxt "#30066"
+msgid "Show all inactive upcomings by default (alternative/recorded/expired)"
+msgstr ""
+
+# empty strings from id 30067 to 30099
 
 # Systeminformation labels
 msgctxt "#30100"
@@ -300,7 +304,7 @@ msgstr ""
 # empty strings from id 30413 to 30420
 
 msgctxt "#30421"
-msgid "Show/hide inactive upcomings"
+msgid "Toggle display of alternative/recorded/expired"
 msgstr ""
 
 msgctxt "#30422"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -33,5 +33,6 @@
     <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />
+    <setting id="inactive_upcomings" type="bool" label="30066" default="true" />
   </category>
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -60,6 +60,7 @@ int           g_iGroupRecordings        = GROUP_RECORDINGS_ALWAYS;
 int           g_iEnableEDL              = ENABLE_EDL_ALWAYS;
 bool          g_bBlockMythShutdown      = DEFAULT_BLOCK_SHUTDOWN;
 bool          g_bLimitTuneAttempts      = DEFAULT_LIMIT_TUNE_ATTEMPTS;
+bool          g_bShowNotRecording       = false;
 
 ///* Client member variables */
 ADDON_STATUS  m_CurStatus               = ADDON_STATUS_UNKNOWN;
@@ -310,6 +311,14 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'limit_tune_attempts' setting, falling back to '%b' as default", DEFAULT_LIMIT_TUNE_ATTEMPTS);
     g_bLimitTuneAttempts = DEFAULT_LIMIT_TUNE_ATTEMPTS;
+  }
+
+  /* Read setting "inactive_upcomings" from settings.xml */
+  if (!XBMC->GetSetting("inactive_upcomings", &g_bShowNotRecording))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'inactive_upcomings' setting, falling back to '%b' as default", DEFAULT_SHOW_NOT_RECORDING);
+    g_bShowNotRecording = DEFAULT_SHOW_NOT_RECORDING;
   }
 
   free (buffer);
@@ -675,6 +684,16 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     XBMC->Log(LOG_INFO, "Changed Setting 'limit_tune_attempts' from %u to %u", g_bLimitTuneAttempts, *(bool*)settingValue);
     if (g_bLimitTuneAttempts != *(bool*)settingValue)
       g_bLimitTuneAttempts = *(bool*)settingValue;
+  }
+  else if (str == "inactive_upcomings")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'inactive_upcomings' from %u to %u", g_bShowNotRecording, *(bool*)settingValue);
+    if (g_bShowNotRecording != *(bool*)settingValue)
+    {
+      g_bShowNotRecording = *(bool*)settingValue;
+      if (g_client)
+        g_client->HandleScheduleChange();
+    }
   }
   return ADDON_STATUS_OK;
 }

--- a/src/client.h
+++ b/src/client.h
@@ -63,6 +63,7 @@
 #define ENABLE_EDL_NEVER                    2
 #define DEFAULT_BLOCK_SHUTDOWN              true
 #define DEFAULT_LIMIT_TUNE_ATTEMPTS         true
+#define DEFAULT_SHOW_NOT_RECORDING          true
 
 /*!
  * @brief PVR macros for string exchange
@@ -111,6 +112,7 @@ extern int          g_iGroupRecordings;
 extern int          g_iEnableEDL;
 extern bool         g_bBlockMythShutdown;
 extern bool         g_bLimitTuneAttempts;       ///< Limit channel tuning attempts to first card
+extern bool         g_bShowNotRecording;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;

--- a/src/cppmyth/MythScheduleHelper75.cpp
+++ b/src/cppmyth/MythScheduleHelper75.cpp
@@ -267,6 +267,57 @@ MythTimerTypeList MythScheduleHelper75::GetTimerTypes() const
             GetRuleRecordingGroupList(),
             GetRuleRecordingGroupDefaultId())));
 
+    m_timerTypeList.push_back(MythTimerTypePtr(new MythTimerType(TIMER_TYPE_UPCOMING_ALTERNATE,
+            PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES |
+            PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+            PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
+            PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
+            PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+            PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP,
+            XBMC->GetLocalizedString(30457), // Alternative
+            GetRulePriorityList(),
+            GetRulePriorityDefaultId(),
+            emptyList,
+            0, // n&v
+            autoExpireList,
+            autoExpire1,
+            GetRuleRecordingGroupList(),
+            GetRuleRecordingGroupDefaultId())));
+
+    m_timerTypeList.push_back(MythTimerTypePtr(new MythTimerType(TIMER_TYPE_UPCOMING_RECORDED,
+            PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES |
+            PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+            PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
+            PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
+            PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+            PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP,
+            XBMC->GetLocalizedString(30458), // Currently recorded
+            GetRulePriorityList(),
+            GetRulePriorityDefaultId(),
+            emptyList,
+            0, // n&v
+            autoExpireList,
+            autoExpire1,
+            GetRuleRecordingGroupList(),
+            GetRuleRecordingGroupDefaultId())));
+
+    m_timerTypeList.push_back(MythTimerTypePtr(new MythTimerType(TIMER_TYPE_UPCOMING_EXPIRED,
+            PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES |
+            PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
+            PVR_TIMER_TYPE_SUPPORTS_START_END_MARGIN |
+            PVR_TIMER_TYPE_SUPPORTS_PRIORITY |
+            PVR_TIMER_TYPE_SUPPORTS_LIFETIME |
+            PVR_TIMER_TYPE_SUPPORTS_RECORDING_GROUP,
+            XBMC->GetLocalizedString(30459), // Expired recording
+            GetRulePriorityList(),
+            GetRulePriorityDefaultId(),
+            emptyList,
+            0, // n&v
+            autoExpireList,
+            autoExpire1,
+            GetRuleRecordingGroupList(),
+            GetRuleRecordingGroupDefaultId())));
+
     m_timerTypeList.push_back(MythTimerTypePtr(new MythTimerType(TIMER_TYPE_OVERRIDE,
             PVR_TIMER_TYPE_FORBIDS_NEW_INSTANCES |
             PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE |
@@ -632,7 +683,24 @@ bool MythScheduleHelper75::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
         if (node->GetMainRule().SearchType() == Myth::ST_ManualSearch)
           entry.timerType = TIMER_TYPE_UPCOMING_MANUAL;
         else
-          entry.timerType = TIMER_TYPE_UPCOMING;
+        {
+          switch (recording.Status())
+          {
+            case Myth::RS_EARLIER_RECORDING:  //will record earlier
+            case Myth::RS_LATER_SHOWING:      //will record later
+              entry.timerType = TIMER_TYPE_UPCOMING_ALTERNATE;
+              break;
+            case Myth::RS_CURRENT_RECORDING:  //Already in the current library
+              entry.timerType = TIMER_TYPE_UPCOMING_RECORDED;
+              break;
+            case Myth::RS_PREVIOUS_RECORDING: //Previoulsy recorded but no longer in the library
+              entry.timerType = TIMER_TYPE_UPCOMING_EXPIRED;
+              break;
+            default:
+              entry.timerType = TIMER_TYPE_UPCOMING;
+              break;
+          }
+        }
     }
     entry.startOffset = rule.StartOffset();
     entry.endOffset = rule.EndOffset();
@@ -645,6 +713,9 @@ bool MythScheduleHelper75::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_OVERRIDE:
     case TIMER_TYPE_UPCOMING_MANUAL:
       entry.epgCheck = true;
@@ -1131,6 +1202,9 @@ MythRecordingRule MythScheduleHelper75::NewFromTimer(const MythTimerEntry& entry
       rule.SetInactive(entry.isInactive);
       return rule;
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_UPCOMING_MANUAL:
     case TIMER_TYPE_ZOMBIE:
       rule.SetType(Myth::RT_SingleRecord);

--- a/src/cppmyth/MythScheduleHelper76.cpp
+++ b/src/cppmyth/MythScheduleHelper76.cpp
@@ -600,6 +600,9 @@ MythRecordingRule MythScheduleHelper76::NewFromTimer(const MythTimerEntry& entry
       rule.SetInactive(entry.isInactive);
       return rule;
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_UPCOMING_MANUAL:
     case TIMER_TYPE_ZOMBIE:
       rule.SetType(Myth::RT_SingleRecord);

--- a/src/cppmyth/MythScheduleHelper85.cpp
+++ b/src/cppmyth/MythScheduleHelper85.cpp
@@ -79,7 +79,24 @@ bool MythScheduleHelper85::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
         if (node->GetMainRule().SearchType() == Myth::ST_ManualSearch)
           entry.timerType = TIMER_TYPE_UPCOMING_MANUAL;
         else
-          entry.timerType = TIMER_TYPE_UPCOMING;
+        {
+          switch (recording.Status())
+          {
+            case Myth::RS_EARLIER_RECORDING:  //will record earlier
+            case Myth::RS_LATER_SHOWING:      //will record later
+              entry.timerType = TIMER_TYPE_UPCOMING_ALTERNATE;
+              break;
+            case Myth::RS_CURRENT_RECORDING:  //Already in the current library
+              entry.timerType = TIMER_TYPE_UPCOMING_RECORDED;
+              break;
+            case Myth::RS_PREVIOUS_RECORDING: //Previoulsy recorded but no longer in the library
+              entry.timerType = TIMER_TYPE_UPCOMING_EXPIRED;
+              break;
+            default:
+              entry.timerType = TIMER_TYPE_UPCOMING;
+              break;
+          }
+        }
     }
     entry.startOffset = rule.StartOffset();
     entry.endOffset = rule.EndOffset();
@@ -92,6 +109,9 @@ bool MythScheduleHelper85::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_OVERRIDE:
     case TIMER_TYPE_UPCOMING_MANUAL:
       entry.epgCheck = true;

--- a/src/cppmyth/MythScheduleManager.cpp
+++ b/src/cppmyth/MythScheduleManager.cpp
@@ -260,6 +260,9 @@ MythScheduleManager::MSM_ERROR MythScheduleManager::UpdateTimer(const MythTimerE
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_DONT_RECORD:
     case TIMER_TYPE_OVERRIDE:
     {
@@ -295,6 +298,9 @@ MythScheduleManager::MSM_ERROR MythScheduleManager::DeleteTimer(const MythTimerE
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
       return DisableRecording(entry.entryIndex);
     case TIMER_TYPE_DONT_RECORD:
     case TIMER_TYPE_OVERRIDE:

--- a/src/cppmyth/MythScheduleManager.cpp
+++ b/src/cppmyth/MythScheduleManager.cpp
@@ -134,7 +134,6 @@ MythScheduleManager::MythScheduleManager(const std::string& server, unsigned pro
 , m_recordings(NULL)
 , m_recordingIndexByRuleId(NULL)
 , m_templates(NULL)
-, m_showNotRecording(false)
 {
   m_control = new Myth::Control(server, protoPort, wsapiPort, wsapiSecurityPin);
   this->Update();
@@ -974,8 +973,13 @@ MythRecordingRuleList MythScheduleManager::GetTemplateRules() const
 
 bool MythScheduleManager::ToggleShowNotRecording()
 {
-  m_showNotRecording ^= true;
-  return m_showNotRecording;
+  g_bShowNotRecording ^= true;
+  return g_bShowNotRecording;
+}
+
+bool MythScheduleManager::ShowNotRecording()
+{
+  return g_bShowNotRecording;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -45,6 +45,9 @@ typedef enum
   TIMER_TYPE_SEARCH_PEOPLE,       // Search people
   // Keep last
   TIMER_TYPE_UPCOMING,            // Upcoming
+  TIMER_TYPE_UPCOMING_ALTERNATE,  // Upcoming will record at another time
+  TIMER_TYPE_UPCOMING_RECORDED,   // Upcoming currently recorded
+  TIMER_TYPE_UPCOMING_EXPIRED,    // Upcoming previously recorded and expired
   TIMER_TYPE_OVERRIDE,            // Override
   TIMER_TYPE_DONT_RECORD,         // Don't record
   TIMER_TYPE_UNHANDLED,           // Unhandled rule

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -188,7 +188,7 @@ public:
   MythRecordingRuleList GetTemplateRules() const;
 
   bool ToggleShowNotRecording();
-  bool ShowNotRecording() const { return m_showNotRecording; }
+  bool ShowNotRecording();
 
   class VersionHelper
   {
@@ -237,7 +237,6 @@ private:
   RecordingIndexByRuleId* m_recordingIndexByRuleId;
   MythRecordingRuleList* m_templates;
 
-  bool m_showNotRecording;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
With Glenn-1990's recent addition to PVR which displays 'disabled' upcomings as a greyed out timer icons and 'conflict_NOK' upcomings as a red timer icon, it seems sensible to make slightly better use of them.
![screenshot041](https://cloud.githubusercontent.com/assets/12870817/13035315/f280218a-d344-11e5-9a1c-3871cff51485.png)

PVR core now also includes the option to hide 'disabled' timers in the sideblade, which can easily remove clutter from the upcomings list.
This PR creates 3 new timer types for 'Alternative', 'Recorded' and 'Expired' upcomings, which are the type of upcomings which aren't currently displayed by default.
![screenshot039](https://cloud.githubusercontent.com/assets/12870817/13035316/f2828f10-d344-11e5-9847-3a216eb75cd2.png)

One of the key benefits of this (other than the upcomings list) is that by selecting a timer in the EPG and selecting 'edit timer' you get to see why it is inactive, and can choose to over-ride it there and then. 
![screenshot040](https://cloud.githubusercontent.com/assets/12870817/13035317/f28344fa-d344-11e5-976a-fbd9bba5b20c.png)
Hey, I don't need to wait for this to record, it's already in my library!

I have also made the 'enable inactive timers' option a global setting, so the user's preference can be remembered across restarts.
![screenshot042](https://cloud.githubusercontent.com/assets/12870817/13035336/81dc20f4-d345-11e5-92ad-9f831f521432.png)

It might be useful to treat some of the the other 'not immediately obvious' reasons why upcomings are 'disabled' in a similar way.  I know there is already the client option 'show status of upcoming' but that isn't immediate enough for my liking.

What do you think?
