### PR TITLE
Separate ThumbnailPath from IconPath

### DIFF
--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -904,6 +904,7 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
 
       // Images
       std::string strIconPath;
+      std::string strThumbnailPath;
       std::string strFanartPath;
       if (m_fileOps)
       {
@@ -915,14 +916,16 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
           if (!channel.IsNull())
             strIconPath = m_fileOps->GetChannelIconPath(channel);
         }
-        else
-          strIconPath = m_fileOps->GetPreviewIconPath(it->second);
+
+        strThumbnailPath = m_fileOps->GetPreviewIconPath(it->second);
+        if (strIconPath.empty())
+          strIconPath = strThumbnailPath;
 
         if (it->second.HasFanart())
           strFanartPath = m_fileOps->GetArtworkPath(it->second, FileOps::FileTypeFanart);
       }
       PVR_STRCPY(tag.strIconPath, strIconPath.c_str());
-      PVR_STRCPY(tag.strThumbnailPath, strIconPath.c_str());
+      PVR_STRCPY(tag.strThumbnailPath, strThumbnailPath.c_str());
       PVR_STRCPY(tag.strFanartPath, strFanartPath.c_str());
 
       // EPG Entry (Enables "Play recording" option and icon)
@@ -1013,6 +1016,7 @@ PVR_ERROR PVRClientMythTV::GetDeletedRecordings(ADDON_HANDLE handle)
 
       // Images
       std::string strIconPath;
+      std::string strThumbnailPath;
       std::string strFanartPath;
       if (m_fileOps)
       {
@@ -1024,14 +1028,16 @@ PVR_ERROR PVRClientMythTV::GetDeletedRecordings(ADDON_HANDLE handle)
           if (!channel.IsNull())
             strIconPath = m_fileOps->GetChannelIconPath(channel);
         }
-        else
-          strIconPath = m_fileOps->GetPreviewIconPath(it->second);
+
+        strThumbnailPath = m_fileOps->GetPreviewIconPath(it->second);
+        if (strIconPath.empty())
+          strIconPath = strThumbnailPath;
 
         if (it->second.HasFanart())
           strFanartPath = m_fileOps->GetArtworkPath(it->second, FileOps::FileTypeFanart);
       }
       PVR_STRCPY(tag.strIconPath, strIconPath.c_str());
-      PVR_STRCPY(tag.strThumbnailPath, strIconPath.c_str());
+      PVR_STRCPY(tag.strThumbnailPath, strThumbnailPath.c_str());
       PVR_STRCPY(tag.strFanartPath, strFanartPath.c_str());
 
       // Unimplemented


### PR DESCRIPTION
The API has separate places for Icon, Fanart, and Thumbnail but currently the mythtv plugin always sets Thumbnail and Icon to the same thing.  These should instead contain different images.
