### PR TITLE
A setting to send (original) Airdate to Kodi instead of the Recording Start Date/Time

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -137,7 +137,11 @@ msgctxt "#30034"
 msgid "Allow recordings to expire"
 msgstr ""
 
-# empty strings from id 30035 to 30048
+# empty strings from id 30035 to 30047
+
+msgctxt "#30048"
+msgid "Show 'Original Airdate' instead of 'Recording Time'"
+msgstr ""
 
 msgctxt "#30049"
 msgid "Recording template"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -30,6 +30,7 @@
     <setting id="tunedelay" type="slider" option="int" range="5,1,30" label="30053" />
     <setting id="limit_tune_attempts" type="bool" label="30065" default="true" />
     <setting id="group_recordings" type="enum" label="30054" lvalues="30055|30056|30057" default="0" />
+    <setting id="use_airdate" type="bool" label="30048" default="false" />
     <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -57,6 +57,7 @@ int           g_iRecTranscoder          = 0;
 bool          g_bDemuxing               = DEFAULT_HANDLE_DEMUXING;
 int           g_iTuneDelay              = DEFAULT_TUNE_DELAY;
 int           g_iGroupRecordings        = GROUP_RECORDINGS_ALWAYS;
+bool          g_bUseAirdate             = DEFAULT_USE_AIRDATE;
 int           g_iEnableEDL              = ENABLE_EDL_ALWAYS;
 bool          g_bBlockMythShutdown      = DEFAULT_BLOCK_SHUTDOWN;
 bool          g_bLimitTuneAttempts      = DEFAULT_LIMIT_TUNE_ATTEMPTS;
@@ -270,6 +271,14 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'group_recordings' setting, falling back to '%i' as default", GROUP_RECORDINGS_ALWAYS);
     g_iGroupRecordings = GROUP_RECORDINGS_ALWAYS;
+  }
+
+  /* Read setting "use_airdate" from settings.xml */
+  if (!XBMC->GetSetting("use_airdate", &g_bUseAirdate))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'use_airdate' setting, falling back to '%b' as default", DEFAULT_USE_AIRDATE);
+    g_bUseAirdate = DEFAULT_USE_AIRDATE;
   }
 
   /* Read setting "enable_edl" from settings.xml */
@@ -628,6 +637,15 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     if (g_iGroupRecordings != *(int*)settingValue)
     {
       g_iGroupRecordings = *(int*)settingValue;
+      PVR->TriggerRecordingUpdate();
+    }
+  }
+  else if (str == "use_airdate")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'use_airdate' from %b to %b", g_bUseAirdate, *(bool*)settingValue);
+    if (g_bUseAirdate != *(bool*)settingValue)
+    {
+      g_bUseAirdate = *(bool*)settingValue;
       PVR->TriggerRecordingUpdate();
     }
   }

--- a/src/client.h
+++ b/src/client.h
@@ -58,6 +58,7 @@
 #define GROUP_RECORDINGS_ALWAYS             0
 #define GROUP_RECORDINGS_ONLY_FOR_SERIES    1
 #define GROUP_RECORDINGS_NEVER              2
+#define DEFAULT_USE_AIRDATE                 false
 #define ENABLE_EDL_ALWAYS                   0
 #define ENABLE_EDL_DIALOG                   1
 #define ENABLE_EDL_NEVER                    2
@@ -108,6 +109,7 @@ extern int          g_iRecTranscoder;
 extern bool         g_bDemuxing;
 extern int          g_iTuneDelay;
 extern int          g_iGroupRecordings;
+extern bool         g_bUseAirdate;
 extern int          g_iEnableEDL;
 extern bool         g_bBlockMythShutdown;
 extern bool         g_bLimitTuneAttempts;       ///< Limit channel tuning attempts to first card

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -866,7 +866,7 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
       memset(&tag, 0, sizeof(PVR_RECORDING));
       tag.bIsDeleted = false;
 
-      tag.recordingTime = it->second.RecordingStartTime();
+      tag.recordingTime = GetRecordingTime(it->second.Airdate(), it->second.RecordingStartTime());
       tag.iDuration = it->second.Duration();
       tag.iPlayCount = it->second.IsWatched() ? 1 : 0;
       //@TODO: tag.iLastPlayedPosition
@@ -983,7 +983,7 @@ PVR_ERROR PVRClientMythTV::GetDeletedRecordings(ADDON_HANDLE handle)
       memset(&tag, 0, sizeof(PVR_RECORDING));
       tag.bIsDeleted = true;
 
-      tag.recordingTime = it->second.RecordingStartTime();
+      tag.recordingTime = GetRecordingTime(it->second.Airdate(), it->second.RecordingStartTime());
       tag.iDuration = it->second.Duration();
       tag.iPlayCount = it->second.IsWatched() ? 1 : 0;
       //@TODO: tag.iLastPlayedPosition
@@ -2612,4 +2612,26 @@ void PVRClientMythTV::FillRecordingAVInfo(MythProgramInfo& programInfo, Myth::St
     // Set video aspec
     programInfo.SetPropsVideoAspec(mInfo.stream_info.aspect);
   }
+}
+
+time_t PVRClientMythTV::GetRecordingTime(time_t airtt, time_t recordingtt)
+{
+  if (!g_bUseAirdate || airtt == 0)
+    return recordingtt;
+
+  /* Airdate is usually a Date, not a time.  So we include the time part from
+  the recording time in order to give the reported time something other than
+  12AM.  If two shows are recorded on the same day, typically they are aired
+  in the correct time order.  Combining airdate and recording time gives us
+  the best possible time to report to the user to allow them to sort by
+  datetime to see the correct episode ordering. */
+  struct tm airtm, rectm;
+  gmtime_r(&airtt, &airtm);
+  gmtime_r(&recordingtt, &rectm);
+
+  airtm.tm_hour = rectm.tm_hour;
+  airtm.tm_min = rectm.tm_min;
+  airtm.tm_sec = rectm.tm_sec;
+
+  return mktime(&airtm);
 }

--- a/src/pvrclient-mythtv.h
+++ b/src/pvrclient-mythtv.h
@@ -220,4 +220,7 @@ private:
    * \brief Parse and fill AV stream infos for a recorded program
    */
   static void FillRecordingAVInfo(MythProgramInfo& programInfo, Myth::Stream *stream);
+
+  /// Get the time that should be reported for this recording
+  static time_t GetRecordingTime(time_t airdate, time_t startDate);
 };


### PR DESCRIPTION
I really don't ever care when I recorded something, I care when it originally aired so that I can sort my episodes by the order in which I should watch them.  This PR adds an option (default to False/Off/The way things currently are) which sends the recording's Airdate (along with the start time) to Kodi instead of the recording start date/time.

For example, sometimes I miss the first airing of a single episode of a show in the middle of a season (signal problems, or backend problems, or something).  I can pick it up later when it airs as a rerun or part of a marathon... but then the recording start date will place it out of sort order with the rest of the show. 

We combine the Airdate (which is usually a Date, no Time information) with the recording start time (not the date part) to get the best guess of what the original airdate and time would be, and to give the best possible guess at how a bunch of episodes should be ordered.

The default behavior is still to just send the recording start date/time as the plugin does today.
