### PR TITLE
Extra timer info

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -205,7 +205,11 @@ msgctxt "#30065"
 msgid "Limit channel tuning attempts"
 msgstr ""
 
-# empty strings from id 30066 to 30099
+msgctxt "#30066"
+msgid "Show all inactive upcomings by default (alternative/recorded/expired)"
+msgstr ""
+
+# empty strings from id 30067 to 30099
 
 # Systeminformation labels
 msgctxt "#30100"
@@ -300,7 +304,7 @@ msgstr ""
 # empty strings from id 30413 to 30420
 
 msgctxt "#30421"
-msgid "Show/hide inactive upcomings"
+msgid "Toggle display of alternative/recorded/expired"
 msgstr ""
 
 msgctxt "#30422"

--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -341,7 +341,17 @@ msgctxt "#30456"
 msgid "Zombie"
 msgstr ""
 
-# empty strings from id 30457 to 30459
+msgctxt "#30457"
+msgid "Alternative"
+msgstr ""
+
+msgctxt "#30458"
+msgid "Currently recorded"
+msgstr ""
+
+msgctxt "#30459"
+msgid "Expired recording"
+msgstr ""
 
 msgctxt "#30460"
 msgid "Manual"
@@ -379,7 +389,11 @@ msgctxt "#30468"
 msgid "Search people"
 msgstr ""
 
-# empty strings from id 30469 to 30500
+msgctxt "#30469"
+msgid "Rule disabled"
+msgstr ""
+
+# empty strings from id 30470 to 30500
 
 msgctxt "#30501"
 msgid "Don't match duplicates"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -33,5 +33,6 @@
     <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />
+    <setting id="inactive_upcomings" type="bool" label="30066" default="true" />
   </category>
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -60,6 +60,7 @@ int           g_iGroupRecordings        = GROUP_RECORDINGS_ALWAYS;
 int           g_iEnableEDL              = ENABLE_EDL_ALWAYS;
 bool          g_bBlockMythShutdown      = DEFAULT_BLOCK_SHUTDOWN;
 bool          g_bLimitTuneAttempts      = DEFAULT_LIMIT_TUNE_ATTEMPTS;
+bool          g_bShowNotRecording       = false;
 
 ///* Client member variables */
 ADDON_STATUS  m_CurStatus               = ADDON_STATUS_UNKNOWN;
@@ -310,6 +311,14 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'limit_tune_attempts' setting, falling back to '%b' as default", DEFAULT_LIMIT_TUNE_ATTEMPTS);
     g_bLimitTuneAttempts = DEFAULT_LIMIT_TUNE_ATTEMPTS;
+  }
+
+  /* Read setting "inactive_upcomings" from settings.xml */
+  if (!XBMC->GetSetting("inactive_upcomings", &g_bShowNotRecording))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'inactive_upcomings' setting, falling back to '%b' as default", DEFAULT_SHOW_NOT_RECORDING);
+    g_bShowNotRecording = DEFAULT_SHOW_NOT_RECORDING;
   }
 
   free (buffer);
@@ -652,6 +661,16 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     XBMC->Log(LOG_INFO, "Changed Setting 'limit_tune_attempts' from %u to %u", g_bLimitTuneAttempts, *(bool*)settingValue);
     if (g_bLimitTuneAttempts != *(bool*)settingValue)
       g_bLimitTuneAttempts = *(bool*)settingValue;
+  }
+  else if (str == "inactive_upcomings")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'inactive_upcomings' from %u to %u", g_bShowNotRecording, *(bool*)settingValue);
+    if (g_bShowNotRecording != *(bool*)settingValue)
+    {
+      g_bShowNotRecording = *(bool*)settingValue;
+      if (g_client)
+        g_client->HandleScheduleChange();
+    }
   }
   return ADDON_STATUS_OK;
 }

--- a/src/client.h
+++ b/src/client.h
@@ -63,6 +63,7 @@
 #define ENABLE_EDL_NEVER                    2
 #define DEFAULT_BLOCK_SHUTDOWN              true
 #define DEFAULT_LIMIT_TUNE_ATTEMPTS         true
+#define DEFAULT_SHOW_NOT_RECORDING          true
 
 /*!
  * @brief PVR macros for string exchange
@@ -111,6 +112,7 @@ extern int          g_iGroupRecordings;
 extern int          g_iEnableEDL;
 extern bool         g_bBlockMythShutdown;
 extern bool         g_bLimitTuneAttempts;       ///< Limit channel tuning attempts to first card
+extern bool         g_bShowNotRecording;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;

--- a/src/cppmyth/MythScheduleHelper76.cpp
+++ b/src/cppmyth/MythScheduleHelper76.cpp
@@ -600,6 +600,10 @@ MythRecordingRule MythScheduleHelper76::NewFromTimer(const MythTimerEntry& entry
       rule.SetInactive(entry.isInactive);
       return rule;
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_RULE_INACTIVE:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_UPCOMING_MANUAL:
     case TIMER_TYPE_ZOMBIE:
       rule.SetType(Myth::RT_SingleRecord);

--- a/src/cppmyth/MythScheduleHelper85.cpp
+++ b/src/cppmyth/MythScheduleHelper85.cpp
@@ -79,7 +79,27 @@ bool MythScheduleHelper85::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
         if (node->GetMainRule().SearchType() == Myth::ST_ManualSearch)
           entry.timerType = TIMER_TYPE_UPCOMING_MANUAL;
         else
-          entry.timerType = TIMER_TYPE_UPCOMING;
+          {
+            switch (recording.Status())
+            {
+              case Myth::RS_EARLIER_RECORDING:  //will record earlier
+              case Myth::RS_LATER_SHOWING:      //will record later
+                entry.timerType = TIMER_TYPE_UPCOMING_ALTERNATE;
+                break;
+              case Myth::RS_CURRENT_RECORDING:  //Already in the current library
+                entry.timerType = TIMER_TYPE_UPCOMING_RECORDED;
+                break;
+              case Myth::RS_PREVIOUS_RECORDING: //Previoulsy recorded but no longer in the library
+                entry.timerType = TIMER_TYPE_UPCOMING_EXPIRED;
+                break;
+              case Myth::RS_INACTIVE:           //Parent rule is disabled
+                entry.timerType = TIMER_TYPE_RULE_INACTIVE;
+                break;
+              default:
+                entry.timerType = TIMER_TYPE_UPCOMING;
+                break;
+            }
+          }
     }
     entry.startOffset = rule.StartOffset();
     entry.endOffset = rule.EndOffset();
@@ -92,6 +112,10 @@ bool MythScheduleHelper85::FillTimerEntryWithUpcoming(MythTimerEntry& entry, con
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_RULE_INACTIVE:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_OVERRIDE:
     case TIMER_TYPE_UPCOMING_MANUAL:
       entry.epgCheck = true;

--- a/src/cppmyth/MythScheduleManager.cpp
+++ b/src/cppmyth/MythScheduleManager.cpp
@@ -134,7 +134,6 @@ MythScheduleManager::MythScheduleManager(const std::string& server, unsigned pro
 , m_recordings(NULL)
 , m_recordingIndexByRuleId(NULL)
 , m_templates(NULL)
-, m_showNotRecording(false)
 {
   m_control = new Myth::Control(server, protoPort, wsapiPort, wsapiSecurityPin);
   this->Update();
@@ -976,8 +975,13 @@ MythRecordingRuleList MythScheduleManager::GetTemplateRules() const
 
 bool MythScheduleManager::ToggleShowNotRecording()
 {
-  m_showNotRecording ^= true;
-  return m_showNotRecording;
+  g_bShowNotRecording ^= true;
+  return g_bShowNotRecording;
+}
+
+bool MythScheduleManager::ShowNotRecording()
+{
+  return g_bShowNotRecording;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/cppmyth/MythScheduleManager.cpp
+++ b/src/cppmyth/MythScheduleManager.cpp
@@ -260,6 +260,10 @@ MythScheduleManager::MSM_ERROR MythScheduleManager::UpdateTimer(const MythTimerE
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_RULE_INACTIVE:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
     case TIMER_TYPE_DONT_RECORD:
     case TIMER_TYPE_OVERRIDE:
     {
@@ -295,6 +299,10 @@ MythScheduleManager::MSM_ERROR MythScheduleManager::DeleteTimer(const MythTimerE
   switch (entry.timerType)
   {
     case TIMER_TYPE_UPCOMING:
+    case TIMER_TYPE_RULE_INACTIVE:
+    case TIMER_TYPE_UPCOMING_ALTERNATE:
+    case TIMER_TYPE_UPCOMING_RECORDED:
+    case TIMER_TYPE_UPCOMING_EXPIRED:
       return DisableRecording(entry.entryIndex);
     case TIMER_TYPE_DONT_RECORD:
     case TIMER_TYPE_OVERRIDE:

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -189,7 +189,7 @@ public:
   MythRecordingRuleList GetTemplateRules() const;
 
   bool ToggleShowNotRecording();
-  bool ShowNotRecording() const { return m_showNotRecording; }
+  bool ShowNotRecording();
 
   class VersionHelper
   {
@@ -238,7 +238,6 @@ private:
   RecordingIndexByRuleId* m_recordingIndexByRuleId;
   MythRecordingRuleList* m_templates;
 
-  bool m_showNotRecording;
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/cppmyth/MythScheduleManager.h
+++ b/src/cppmyth/MythScheduleManager.h
@@ -45,6 +45,10 @@ typedef enum
   TIMER_TYPE_SEARCH_PEOPLE,       // Search people
   // Keep last
   TIMER_TYPE_UPCOMING,            // Upcoming
+  TIMER_TYPE_RULE_INACTIVE,       // Parent Rule is disable
+  TIMER_TYPE_UPCOMING_ALTERNATE,  // Upcoming will record at another time
+  TIMER_TYPE_UPCOMING_RECORDED,   // Upcoming currently recorded
+  TIMER_TYPE_UPCOMING_EXPIRED,    // Upcoming previously recorded and expired
   TIMER_TYPE_OVERRIDE,            // Override
   TIMER_TYPE_DONT_RECORD,         // Don't record
   TIMER_TYPE_UNHANDLED,           // Unhandled rule


### PR DESCRIPTION
Jean-Luc,
This change adds some extra timer types which I find make the list of Timers much easier to view.
You can now see why something won't record.
![screenshot048](https://cloud.githubusercontent.com/assets/12870817/19909290/d57c9386-a07e-11e6-9698-08b455f16c44.png)
Which previously was pretty hard to understand
![screenshot049](https://cloud.githubusercontent.com/assets/12870817/19909329/16b20e6c-a07f-11e6-9aed-767b2ef4fc40.png)
As the timers list is now useful (much like a MythWeb upcomings page :+1:) I made the 'show/hide' client option a stored option and made the title easier to understand.
![screenshot050](https://cloud.githubusercontent.com/assets/12870817/19909543/29673a0e-a080-11e6-81ca-8956db5939b7.png)

I've been using this for months (along with some other changes which aren't ready yet in my personal build) so I know it works well. 

Maybe you agree?

Andrew