### PR TITLE
Option to prompt the user to delete a recording after they finish watching it

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -137,7 +137,11 @@ msgctxt "#30034"
 msgid "Allow recordings to expire"
 msgstr ""
 
-# empty strings from id 30035 to 30047
+# empty strings from id 30035 to 30046
+
+msgctxt "#30047"
+msgid "Prompt to delete at end of recording"
+msgstr ""
 
 msgctxt "#30048"
 msgid "Show 'Original Airdate' instead of 'Recording Time'"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -35,5 +35,6 @@
     <setting id="channel_icons" type="bool" label="30063" default="true" />
     <setting id="recording_icons" type="bool" label="30064" default="true" />
     <setting id="inactive_upcomings" type="bool" label="30066" default="true" />
+    <setting id="prompt_delete" type="bool" label="30047" default="false" />
   </category>
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -61,6 +61,7 @@ int           g_iEnableEDL              = ENABLE_EDL_ALWAYS;
 bool          g_bBlockMythShutdown      = DEFAULT_BLOCK_SHUTDOWN;
 bool          g_bLimitTuneAttempts      = DEFAULT_LIMIT_TUNE_ATTEMPTS;
 bool          g_bShowNotRecording       = false;
+bool          g_bPromptDeleteAtEnd      = false;
 
 ///* Client member variables */
 ADDON_STATUS  m_CurStatus               = ADDON_STATUS_UNKNOWN;
@@ -327,6 +328,14 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'inactive_upcomings' setting, falling back to '%b' as default", DEFAULT_SHOW_NOT_RECORDING);
     g_bShowNotRecording = DEFAULT_SHOW_NOT_RECORDING;
+  }
+
+  /* Read setting "use_airdate" from settings.xml */
+  if (!XBMC->GetSetting("prompt_delete", &g_bPromptDeleteAtEnd))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'prompt_delete' setting, falling back to '%b' as default", DEFAULT_PROMPT_DELETE);
+    g_bPromptDeleteAtEnd = DEFAULT_PROMPT_DELETE;
   }
 
   free (buffer);
@@ -686,6 +695,12 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
       if (g_client)
         g_client->HandleScheduleChange();
     }
+  }
+  else if (str == "prompt_delete")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'prompt_delete' from %b to %b", g_bPromptDeleteAtEnd, *(bool*)settingValue);
+    if (g_bPromptDeleteAtEnd != *(bool*)settingValue)
+      g_bPromptDeleteAtEnd = *(bool*)settingValue;
   }
   return ADDON_STATUS_OK;
 }

--- a/src/client.h
+++ b/src/client.h
@@ -65,6 +65,7 @@
 #define DEFAULT_BLOCK_SHUTDOWN              true
 #define DEFAULT_LIMIT_TUNE_ATTEMPTS         true
 #define DEFAULT_SHOW_NOT_RECORDING          true
+#define DEFAULT_PROMPT_DELETE               false
 
 /*!
  * @brief PVR macros for string exchange
@@ -115,6 +116,7 @@ extern int          g_iEnableEDL;
 extern bool         g_bBlockMythShutdown;
 extern bool         g_bLimitTuneAttempts;       ///< Limit channel tuning attempts to first card
 extern bool         g_bShowNotRecording;
+extern bool         g_bPromptDeleteAtEnd;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -1208,19 +1208,33 @@ PVR_ERROR PVRClientMythTV::SetRecordingPlayCount(const PVR_RECORDING &recording,
       if (g_bExtraDebug)
         XBMC->Log(LOG_DEBUG, "%s: Set watched state for %s", __FUNCTION__, recording.strRecordingId);
       ForceUpdateRecording(it);
-      return PVR_ERROR_NO_ERROR;
     }
     else
     {
       XBMC->Log(LOG_DEBUG, "%s: Failed setting watched state for: %s", __FUNCTION__, recording.strRecordingId);
-      return PVR_ERROR_NO_ERROR;
     }
+
+    if (g_bPromptDeleteAtEnd && count > 0)
+    {
+      std::string dispTitle = MakeProgramTitle(it->second.Title(), it->second.Subtitle());
+      if (GUI->Dialog_YesNo_ShowAndGetInput(XBMC->GetLocalizedString(122),
+	    XBMC->GetLocalizedString(19112), "", dispTitle.c_str(),
+	    "", XBMC->GetLocalizedString(117)))
+      {
+	if (m_control->DeleteRecording(*(it->second.GetPtr())))
+	  XBMC->Log(LOG_DEBUG, "%s: Deleted recording %s", __FUNCTION__, it->first.c_str());
+	else
+	  XBMC->Log(LOG_ERROR, "%s: Failed to delete recording %s", __FUNCTION__, it->first.c_str());
+      }
+    }
+
+    return PVR_ERROR_NO_ERROR;
   }
   else
   {
     XBMC->Log(LOG_DEBUG, "%s: Recording %s does not exist", __FUNCTION__, recording.strRecordingId);
+    return PVR_ERROR_FAILED;
   }
-  return PVR_ERROR_FAILED;
 }
 
 PVR_ERROR PVRClientMythTV::SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)


### PR DESCRIPTION
MythTV frontend has an option to ask the user if they would like to delete a recording when they finish watching it.  Also discussed in this thread: http://forum.kodi.tv/showthread.php?tid=249287

This PR provides a similar feature (optional, defaults to disabled) for pvr.mythtv.

We accomplish this by prompting them if they are closing/stopping playback and they are at least 95% through the stream at that time.  Unfortunately opening a dialog during `CloseRecordedStream()` puts Kodi Krypton into a deadlock, so we have to launch a thread to prompt the user and execute the delete asynchronously.
