### PR TITLE
UseAirdate is sending recordings with incorrect times

### DIFF
--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -2591,9 +2591,8 @@ time_t PVRClientMythTV::GetRecordingTime(time_t airtt, time_t recordingtt)
   the best possible time to report to the user to allow them to sort by
   datetime to see the correct episode ordering. */
   struct tm airtm, rectm;
-  gmtime_r(&airtt, &airtm);
-  gmtime_r(&recordingtt, &rectm);
-
+  localtime_r(&airtt, &airtm);
+  localtime_r(&recordingtt, &rectm);
   airtm.tm_hour = rectm.tm_hour;
   airtm.tm_min = rectm.tm_min;
   airtm.tm_sec = rectm.tm_sec;


### PR DESCRIPTION
The UseAirdate option from #47 is sending times incorrectly and kodi is showing what looks like GMT times instead of local times.