### PR TITLE
no confirmation dialog on startup

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -383,19 +383,7 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
       }
       default:
       {
-        if (!g_bNotifyAddonFailure)
-          m_CurStatus = ADDON_STATUS_NEED_SETTINGS;
-        else
-        {
-          // HEADING: Connection failed
-          // No response from MythTV backend.
-          // Do you want to retry ?
-          std::string msg = XBMC->GetLocalizedString(30304);
-          msg.append("\n").append(XBMC->GetLocalizedString(30113));
-          bool canceled = false;
-          if (!GUI->Dialog_YesNo_ShowAndGetInput(XBMC->GetLocalizedString(30112), msg.c_str(), canceled) && !canceled)
-            m_CurStatus = ADDON_STATUS_NEED_SETTINGS;
-        }
+        // do nothing
         break;
       }
     }


### PR DESCRIPTION
do not ask the user if he wants to retry connecting to the backend if
the backend does not respond.