### PR TITLE
libXBMC_codec.h removed and changed to libXBMC_pvr.h

### DIFF
--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -6,8 +6,7 @@
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="5.2.1"/>
-    <import addon="xbmc.codec" version="1.0.1"/>
+    <import addon="xbmc.pvr" version="5.2.2"/>
     <import addon="kodi.guilib" version="5.11.0"/>
   </requires>
   <extension

--- a/src/avinfo.cpp
+++ b/src/avinfo.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include <xbmc_codec_types.h>
+#include <xbmc_pvr_types.h>
 
 #include "avinfo.h"
 #include "demuxer/debug.h"
@@ -282,7 +282,7 @@ void AVInfo::populate_pvr_streams()
   for (std::vector<TSDemux::ElementaryStream*>::const_iterator it = es_streams.begin(); it != es_streams.end(); it++)
   {
     const char* codec_name = (*it)->GetStreamCodecName();
-    xbmc_codec_t codec = CODEC->GetCodecByName(codec_name);
+    xbmc_codec_t codec = PVR->GetCodecByName(codec_name);
     if (codec.codec_type != XBMC_CODEC_TYPE_UNKNOWN)
     {
       // Find the main stream:

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -78,7 +78,6 @@ PVRClientLauncher       *g_launcher     = NULL;
 CHelper_libXBMC_addon   *XBMC           = NULL;
 CHelper_libXBMC_pvr     *PVR            = NULL;
 CHelper_libKODI_guilib  *GUI            = NULL;
-CHelper_libXBMC_codec   *CODEC          = NULL;
 
 extern "C" {
 
@@ -132,18 +131,6 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     return ADDON_STATUS_PERMANENT_FAILURE;
   }
   XBMC->Log(LOG_DEBUG, "Register handle @ libXBMC_gui...done");
-
-  XBMC->Log(LOG_DEBUG, "Register handle @ libXBMC_codec...");
-  CODEC = new CHelper_libXBMC_codec;
-  if (!CODEC->RegisterMe(hdl))
-  {
-    SAFE_DELETE(CODEC);
-    SAFE_DELETE(PVR);
-    SAFE_DELETE(XBMC);
-    SAFE_DELETE(GUI);
-    return ADDON_STATUS_PERMANENT_FAILURE;
-  }
-  XBMC->Log(LOG_DEBUG, "Register handle @ libXBMC_codec...done");
 
   m_CurStatus    = ADDON_STATUS_UNKNOWN;
   g_szUserPath   = pvrprops->strUserPath;
@@ -425,7 +412,6 @@ void ADDON_Destroy()
     g_bCreated = false;
     SAFE_DELETE(g_launcher);
     SAFE_DELETE(g_client);
-    SAFE_DELETE(CODEC);
     SAFE_DELETE(PVR);
     SAFE_DELETE(XBMC);
     SAFE_DELETE(GUI);

--- a/src/client.h
+++ b/src/client.h
@@ -28,7 +28,6 @@
 #include <libXBMC_addon.h>
 #include <libXBMC_pvr.h>
 #include <libKODI_guilib.h>
-#include <libXBMC_codec.h>
 
 #define LIVETV_CONFLICT_STRATEGY_HASLATER   0
 #define LIVETV_CONFLICT_STRATEGY_STOPTV     1
@@ -123,6 +122,5 @@ extern bool         g_bUseBackendBookmarks;
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;
 extern CHelper_libKODI_guilib       *GUI;
-extern CHelper_libXBMC_codec        *CODEC;
 
 #endif /* CLIENT_H */


### PR DESCRIPTION
Related to Kodi Pull Request xbmc/xbmc#12028 where libXBMC_codec.h becomes removed.