### PR TITLE
Fix compatibility with PVR Addon API 5.5.0

### DIFF
--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="5.1.3"
+  version="5.2.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,6 @@
+v5.2.0
+- Update to PVR addon API v5.5.0
+
 v5.1.3
 - Discard upcoming with invalid channel
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -774,11 +774,6 @@ PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time
  * PVR Channel Functions
  */
 
-unsigned int GetChannelSwitchDelay(void)
-{
-  return 0;
-}
-
 int GetChannelsAmount()
 {
   if (g_client == NULL)
@@ -1014,14 +1009,6 @@ int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize)
   return dataread;
 }
 
-bool SwitchChannel(const PVR_CHANNEL &channel)
-{
-  if (g_client == NULL)
-    return false;
-
-  return g_client->SwitchChannel(channel);
-}
-
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 {
   if (g_client == NULL)
@@ -1161,6 +1148,7 @@ bool IsTimeshifting(void) { return true; }
  * Unused API Functions
  */
 
+PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES *) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES *) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -626,7 +626,6 @@ PVR_ERROR PVRClientMythTV::GetChannels(ADDON_HANDLE handle, bool bRadio)
           PVR_STRCPY(tag.strIconPath, "");
 
         // Unimplemented
-        PVR_STRCPY(tag.strStreamURL, "");
         PVR_STRCPY(tag.strInputFormat, "");
         tag.iEncryptionSystem = 0;
 
@@ -2048,23 +2047,6 @@ int PVRClientMythTV::ReadLiveStream(unsigned char *pBuffer, unsigned int iBuffer
   if (m_dummyStream)
     return m_dummyStream->Read(pBuffer, iBufferSize);
   return -1;
-}
-
-bool PVRClientMythTV::SwitchChannel(const PVR_CHANNEL &channel)
-{
-  if (g_bExtraDebug)
-    XBMC->Log(LOG_DEBUG,"%s: chanid: %u, channum: %u", __FUNCTION__, channel.iUniqueId, channel.iChannelNumber);
-
-  // Begin critical section
-  CLockObject lock(m_lock);
-  // Stop the live for reopening
-  if (m_liveStream)
-    m_liveStream->StopLiveTV();
-  SAFE_DELETE(m_dummyStream);
-  // Try reopening for channel
-  if (OpenLiveStream(channel))
-    return true;
-  return false;
 }
 
 long long PVRClientMythTV::SeekLiveStream(long long iPosition, int iWhence)

--- a/src/pvrclient-mythtv.h
+++ b/src/pvrclient-mythtv.h
@@ -116,7 +116,6 @@ public:
   bool OpenLiveStream(const PVR_CHANNEL &channel);
   void CloseLiveStream();
   int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize);
-  bool SwitchChannel(const PVR_CHANNEL &channel);
   long long SeekLiveStream(long long iPosition, int iWhence);
   long long LengthLiveStream();
   PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus);


### PR DESCRIPTION
Minimalistic changes to make the addon compatible again with the current kodi v18 master.

Related PRs: https://github.com/xbmc/xbmc/pull/12552, https://github.com/xbmc/xbmc/pull/12598, https://github.com/xbmc/xbmc/pull/12609