### PR TITLE
 PVR API 5.6.0

### DIFF
--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="5.2.0"
+  version="5.3.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,5 +1,8 @@
+v5.3.0
+- Updated to PVR addon API v5.6.0
+
 v5.2.0
-- Update to PVR addon API v5.5.0
+- Updated to PVR addon API v5.5.0
 
 v5.1.3
 - Discard upcoming with invalid channel

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -946,7 +946,6 @@ PVR_ERROR GetTimers(ADDON_HANDLE handle)
   if (g_client == NULL)
     return PVR_ERROR_SERVER_ERROR;
 
-  /* TODO: Change implementation to get support for the timer features introduced with PVR API 1.9.7 */
   return g_client->GetTimers(handle);
 }
 
@@ -1155,10 +1154,11 @@ DemuxPacket* DemuxRead(void) { return NULL; }
 void DemuxFlush(void) {}
 bool SeekTime(double, bool, double *) { return false; }
 void DemuxReset() {}
-const char * GetLiveStreamURL(const PVR_CHANNEL &) { return ""; }
 void SetSpeed(int) {};
 PVR_ERROR SetEPGTimeFrame(int) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetDescrambleInfo(PVR_DESCRAMBLE_INFO*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetChannelStreamProperties(const PVR_CHANNEL*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR GetRecordingStreamProperties(const PVR_RECORDING*, PVR_NAMED_VALUE*, unsigned int*) { return PVR_ERROR_NOT_IMPLEMENTED; }
 
 } //end extern "C"

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -941,7 +941,6 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
       tag.iLifetime = 0;
       tag.iPriority = 0;
       PVR_STRCPY(tag.strPlotOutline, "");
-      PVR_STRCPY(tag.strStreamURL, "");
 
       PVR->TransferRecordingEntry(handle, &tag);
     }
@@ -1051,7 +1050,6 @@ PVR_ERROR PVRClientMythTV::GetDeletedRecordings(ADDON_HANDLE handle)
       tag.iLifetime = 0;
       tag.iPriority = 0;
       PVR_STRCPY(tag.strPlotOutline, "");
-      PVR_STRCPY(tag.strStreamURL, "");
 
       /* TODO: PVR API 5.0.0: Implement this */
       tag.iChannelUid = PVR_CHANNEL_INVALID_UID;


### PR DESCRIPTION
- Remove GetLiveStreamURL. 
- Remove PVR_RECORDING::strStreamURL. 
- Add GetChannelStreamProperties. 
- Add GetRecordingStreamProperties.

https://github.com/xbmc/xbmc/pull/12660