### PR TITLE
[win10] fix build for uwp

### DIFF
--- a/lib/cppmyth/src/private/os/windows/winpthreads.c
+++ b/lib/cppmyth/src/private/os/windows/winpthreads.c
@@ -483,6 +483,7 @@ void pthread_testcancel(void)
 
 int pthread_cancel(pthread_t t)
 {
+#if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
   if (t->p_state & PTHREAD_CANCEL_ASYNCHRONOUS)
   {
     /* Dangerous asynchronous cancelling */
@@ -511,6 +512,7 @@ int pthread_cancel(pthread_t t)
     ResumeThread(t->h);
   }
   else
+#endif
   {
     /* Safe deferred Cancelling */
     t->cancelled = 1;


### PR DESCRIPTION
I just ifdef  a part of `pthread_cancel` in case of `PTHREAD_CANCEL_ASYNCHRONOUS` for uwp platform because `SetThreadContext` unavailable on uwp and I didn't find usage of `PTHREAD_CANCEL_ASYNCHRONOUS` somewhere in cppmyth