### PR TITLE
Allow user to configure color display for damaged recordings.

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -137,7 +137,11 @@ msgctxt "#30034"
 msgid "Allow recordings to expire"
 msgstr ""
 
-# empty strings from id 30035 to 30046
+# empty strings from id 30035 to 30045
+
+msgctxt "#30046"
+msgid "Show damaged recordings as color"
+msgstr
 
 msgctxt "#30047"
 msgid "Prompt to delete the watched recording"

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -20,6 +20,7 @@
     <setting id="inactive_upcomings" type="bool" label="30066" default="true" />
     <setting id="prompt_delete" type="bool" label="30047" default="false" />
     <setting id="root_default_group" type="bool" label="30069" default="false" />
+    <setting id="damaged_color" type="text" label="30046" default="yellow" />
   </category>
   <category label="30049">
     <setting id="rec_template_provider" type="enum" label="30020" lvalues="30021|30022" default="1" />

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -67,6 +67,7 @@ bool          g_bShowNotRecording       = DEFAULT_SHOW_NOT_RECORDING;
 bool          g_bPromptDeleteAtEnd      = DEFAULT_PROMPT_DELETE;
 bool          g_bUseBackendBookmarks    = DEFAULT_BACKEND_BOOKMARKS;
 bool          g_bRootDefaultGroup       = DEFAULT_ROOT_DEFAULT_GROUP;
+std::string   g_szDamagedColor          = DEFAULT_DAMAGED_COLOR;
 
 ///* Client member variables */
 ADDON_STATUS  m_CurStatus               = ADDON_STATUS_UNKNOWN;
@@ -347,6 +348,17 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     XBMC->Log(LOG_ERROR, "Couldn't get 'root_default_group' setting, falling back to '%u' as default", DEFAULT_ROOT_DEFAULT_GROUP);
     g_bRootDefaultGroup = DEFAULT_ROOT_DEFAULT_GROUP;
   }
+
+  /* Read setting "damaged_color" from settings.xml */
+  if (XBMC->GetSetting("damaged_color", buffer))
+    g_szDamagedColor = buffer;
+  else
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'damaged_color' setting, falling back to '%s' as default", DEFAULT_DAMAGED_COLOR);
+    g_szDamagedColor = DEFAULT_DAMAGED_COLOR;
+  }
+  buffer[0] = 0;
 
   free (buffer);
   XBMC->Log(LOG_DEBUG, "Loading settings...done");

--- a/src/client.h
+++ b/src/client.h
@@ -68,6 +68,7 @@
 #define DEFAULT_LIVETV_RECORDINGS           true
 #define DEFAULT_BACKEND_BOOKMARKS           true
 #define DEFAULT_ROOT_DEFAULT_GROUP          false
+#define DEFAULT_DAMAGED_COLOR               "yellow"
 /*!
  * @brief PVR macros for string exchange
  */
@@ -119,6 +120,7 @@ extern bool         g_bShowNotRecording;
 extern bool         g_bPromptDeleteAtEnd;
 extern bool         g_bUseBackendBookmarks;
 extern bool         g_bRootDefaultGroup;
+extern std::string  g_szDamagedColor;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr          *PVR;

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -909,10 +909,10 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
 
       std::string str; // a temporary string to build formating label
       std::string title(it->second.Title());
-      if (it->second.IsDamaged())
+      if (it->second.IsDamaged() && !g_szDamagedColor.empty())
       {
         str.assign(title);
-        title.assign("[COLOR yellow]").append(str).append("[/COLOR]");
+        title.assign("[COLOR ").append(g_szDamagedColor).append("]").append(str).append("[/COLOR]");
       }
 
       PVR_STRCPY(tag.strRecordingId, id.c_str());


### PR DESCRIPTION
The new yellow "damaged recording" display does not look good on some skins.  So I made the color configurable.  Additionally, it can be disabled entirely by making the color blank.
