### PR TITLE
All EDL to be sent as SCENE rather than COMM_BREAK

### DIFF
--- a/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.mythtv/resources/language/resource.language.en_gb/strings.po
@@ -468,3 +468,8 @@ msgstr ""
 msgctxt "#30509"
 msgid "Keep %d newest and expire old"
 msgstr ""
+
+msgctxt "#30510"
+msgid "Scene Only"
+msgstr ""
+

--- a/pvr.mythtv/resources/settings.xml
+++ b/pvr.mythtv/resources/settings.xml
@@ -16,7 +16,7 @@
     <setting id="livetv_recordings" type="bool" label="30067" default="true" />
     <setting id="group_recordings" type="enum" label="30054" lvalues="30055|30056|30057" default="1" />
     <setting id="use_airdate" type="bool" label="30048" default="false" />
-    <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061" default="0" />
+    <setting id="enable_edl" type="enum" label="30058" lvalues="30059|30060|30061|30510" default="0" />
     <setting id="inactive_upcomings" type="bool" label="30066" default="true" />
     <setting id="prompt_delete" type="bool" label="30047" default="false" />
     <setting id="root_default_group" type="bool" label="30069" default="false" />

--- a/src/client.h
+++ b/src/client.h
@@ -61,6 +61,7 @@
 #define ENABLE_EDL_ALWAYS                   0
 #define ENABLE_EDL_DIALOG                   1
 #define ENABLE_EDL_NEVER                    2
+#define ENABLE_EDL_SCENE                    3
 #define DEFAULT_BLOCK_SHUTDOWN              true
 #define DEFAULT_LIMIT_TUNE_ATTEMPTS         true
 #define DEFAULT_SHOW_NOT_RECORDING          true

--- a/src/pvrclient-mythtv.cpp
+++ b/src/pvrclient-mythtv.cpp
@@ -1466,6 +1466,19 @@ PVR_ERROR PVRClientMythTV::GetRecordingEdl(const PVR_RECORDING &recording, PVR_E
     switch ((*it)->markType)
     {
       case Myth::MARK_COMM_START:
+        startPtr = *it;
+        if (g_iEnableEDL == ENABLE_EDL_SCENE)
+        {
+          PVR_EDL_ENTRY entry;
+	  double e = (double)((*it)->markValue) / rate;
+          entry.end = entry.start = (int64_t)(e * 1000.0);
+          entry.type = PVR_EDL_TYPE_SCENE;
+          entries[index] = entry;
+          index++;
+	  if (g_bExtraDebug)
+            XBMC->Log(LOG_DEBUG, "%s: SCENE @ %9.3f", __FUNCTION__, e);
+        }
+        break;
       case Myth::MARK_CUT_START:
         startPtr = *it;
         break;
@@ -1475,13 +1488,23 @@ PVR_ERROR PVRClientMythTV::GetRecordingEdl(const PVR_RECORDING &recording, PVR_E
           PVR_EDL_ENTRY entry;
           double s = (double)(startPtr->markValue) / rate;
           double e = (double)((*it)->markValue) / rate;
-          entry.start = (int64_t)(s * 1000.0);
-          entry.end = (int64_t)(e * 1000.0);
-          entry.type = PVR_EDL_TYPE_COMBREAK;
+          if (g_iEnableEDL == ENABLE_EDL_SCENE)
+          {
+            entry.start = entry.end = (int64_t)(e * 1000.0);
+            entry.type = PVR_EDL_TYPE_SCENE;
+            if (g_bExtraDebug)
+              XBMC->Log(LOG_DEBUG, "%s: SCENE @ %9.3f", __FUNCTION__, e);
+          }
+          else
+          {
+            entry.start = (int64_t)(s * 1000.0);
+            entry.end = (int64_t)(e * 1000.0);
+            entry.type = PVR_EDL_TYPE_COMBREAK;
+            if (g_bExtraDebug)
+              XBMC->Log(LOG_DEBUG, "%s: COMBREAK %9.3f - %9.3f", __FUNCTION__, s, e);
+          }
           entries[index] = entry;
           index++;
-          if (g_bExtraDebug)
-            XBMC->Log(LOG_DEBUG, "%s: COMBREAK %9.3f - %9.3f", __FUNCTION__, s, e);
         }
         startPtr.reset();
         break;


### PR DESCRIPTION
This is an implementation of the requested feature in #60.  Using this feature COMM_BREAKS can be sent as SCENEs instead of as BREAKs.  So they will not automatically be skipped, but they can be seeked past.

HOWEVER, when they are sent as a SCENE they do NOT popup a "commercial break" notification.  So I'm not sure how useful this actually is.  But I had half an hour to kill so .... here it is.