### PR TITLE
[pvr.mythtv] bump to 6.1.0

### DIFF
--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="6.0.0"
+  version="6.1.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,6 @@
+v6.1.0
+- Update to GUI addon API v5.14.0
+
 v6.0.0
 - Update to PVR addon API v6.0.0
 


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required

(only merge once the mentioned PR is merged)