### PR TITLE
[debian] fix packaging after 87292e51584236a49fa1751fb293bd0104610edf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-mythtv
 Priority: extra
 Maintainer: janbar <jlbarriere68@gmail.com>
-Build-Depends: debhelper (>= 9.0.0), cmake,
+Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
                kodi-addon-dev, zlib1g-dev
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
the breaking PR removed the implicit dependency on p8-platform