### PR TITLE
Remove p8-platform dependency, it is no longer used.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 
-include_directories(${p8-platform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways
                     ${PROJECT_SOURCE_DIR}/lib/cppmyth/src)
 
 add_definitions(-DUSE_DEMUX -D__STDC_FORMAT_MACROS)
@@ -31,7 +29,7 @@ file (GLOB MYTHTV_HEADERS
 
 add_subdirectory(lib/cppmyth)
 
-set(DEPLIBS ${p8-platform_LIBRARIES} cppmyth)
+set(DEPLIBS cppmyth)
 if(WIN32)
   list(APPEND DEPLIBS ws2_32)
 else()

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-pvr-mythtv
 Priority: extra
 Maintainer: janbar <jlbarriere68@gmail.com>
-Build-Depends: debhelper (>= 9.0.0), cmake, libp8-platform-dev,
+Build-Depends: debhelper (>= 9.0.0), cmake,
                kodi-addon-dev, zlib1g-dev
 Standards-Version: 3.9.4
 Section: libs


### PR DESCRIPTION
Looks like p8-platform is no longer needed after 802b671.