### PR TITLE
Create sync-addon-metadata-translations.yml

### DIFF
--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -1,0 +1,45 @@
+name: Sync addon metadata translations
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - '**addon.xml.in'
+      - '**resource.language.**strings.po'
+
+jobs:
+  default:
+    if: github.repository == 'janbar/pvr.mythtv'
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: project
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/xbmc/sync_addon_metadata_translations.git
+
+      - name: Run sync-addon-metadata-translations
+        run: |
+          sync-addon-metadata-translations
+        working-directory: ./project
+
+      - name: Create PR for sync-addon-metadata-translations changes
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Sync of addon metadata translations
+          title: Sync of addon metadata translations
+          body: Sync of addon metadata translations triggered by ${{ github.sha }}
+          branch: amt-sync
+          delete-branch: true
+          path: ./project


### PR DESCRIPTION
This workflow will sync metadata (`description`, `summary`, `disclaimer` etc.) between addon.xml and language files.

First time the action runs all metadata will be copied from addon.xml to the language files.
When changes are made to addon.xml or the language files, a pull request will be made to sync those changes.