### PR TITLE
[Matrix] final Matrix change to correct test builds and take as Version 19.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
           CC: gcc
           CXX: g++
           DEBIAN_BUILD: true
-        #- os: ubuntu-18.04
-          #CC: gcc
-          #CXX: g++
-        #- os: ubuntu-18.04
-          #CC: clang
-          #CXX: clang++
-        #- os: macos-10.15
+        - os: ubuntu-18.04
+          CC: gcc
+          CXX: g++
+        - os: ubuntu-18.04
+          CC: clang
+          CXX: clang++
+        - os: macos-10.15
     steps:
     - name: Install needed ubuntu depends
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
       env:
         DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
       run: |
-        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
     - name: Checkout Kodi repo
       uses: actions/checkout@v2
       with:
         repository: xbmc/xbmc
-        ref: master
+        ref: Matrix
         path: xbmc
     - name: Checkout pvr.mythtv repo
       uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
       run: |
         if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir -p build && cd build; fi
         if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=${{ github.workspace }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons; fi
-        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep ${{ github.workspace }}/${app_id}; fi
     - name: Build
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       osx_image: xcode10.2
 
 before_install:
-  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
 
@@ -43,12 +43,12 @@ before_install:
 #
 before_script:
   - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
-  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
   - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
   - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
   - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
-  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
   - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
 script: 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ MythTV PVR client addon for [Kodi](http://kodi.tv)
 
 ## Build instructions
 When building the addon you have to use the correct branch depending on which version of Kodi you're building against.
-For example, if you're building the `master` branch of Kodi you should checkout the `master` branch of this repository. Also make sure you follow this README from the branch in question.
+For example, if you're building the `Matrix` branch of Kodi you should checkout the `Matrix` branch of this repository. Also make sure you follow this README from the branch in question.
 
 ### Linux
 
-    git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
+    git clone --branch Matrix --depth=1 https://github.com/xbmc/xbmc.git
     git clone --branch Matrix https://github.com/janbar/pvr.mythtv.git
     cd pvr.mythtv && mkdir build && cd build
     cmake -DADDONS_TO_BUILD=pvr.mythtv -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug \

--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="7.3.4"
+  version="19.0.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,10 @@
+v19.0.0
+- Translations updates from Weblate
+- Changed test builds to 'Kodi 19 Matrix'
+- Increased version to 19.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+
 v7.3.4
 - Update translation files
 


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.

Are the version usages here and on the Nexus request OK for you?