### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
           CC: gcc
           CXX: g++
           DEBIAN_BUILD: true
-        #- os: ubuntu-18.04
-          #CC: gcc
-          #CXX: g++
-        #- os: ubuntu-18.04
-          #CC: clang
-          #CXX: clang++
-        #- os: macos-10.15
+        - os: ubuntu-18.04
+          CC: gcc
+          CXX: g++
+        - os: ubuntu-18.04
+          CC: clang
+          CXX: clang++
+        - os: macos-10.15
     steps:
     - name: Install needed ubuntu depends
       env:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/janbar/pvr.mythtv/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/janbar/pvr.mythtv/actions/workflows/build.yml)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/janbar/job/pvr.mythtv/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/janbar%2Fpvr.mythtv/branches/)
+[![Build and run tests](https://github.com/janbar/pvr.mythtv/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/janbar/pvr.mythtv/actions/workflows/build.yml)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/janbar/job/pvr.mythtv/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/janbar%2Fpvr.mythtv/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/3115/badge.svg)](https://scan.coverity.com/projects/3115)
 
 # MythTV PVR
@@ -13,7 +13,7 @@ For example, if you're building the `master` branch of Kodi you should checkout 
 ### Linux
 
     git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
-    git clone --branch Matrix https://github.com/janbar/pvr.mythtv.git
+    git clone --branch Nexus https://github.com/janbar/pvr.mythtv.git
     cd pvr.mythtv && mkdir build && cd build
     cmake -DADDONS_TO_BUILD=pvr.mythtv -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=ON ../../xbmc/cmake/addons

--- a/pvr.mythtv/addon.xml.in
+++ b/pvr.mythtv/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="7.3.4"
+  version="20.0.0"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>@ADDON_DEPENDS@</requires>

--- a/pvr.mythtv/changelog.txt
+++ b/pvr.mythtv/changelog.txt
@@ -1,3 +1,10 @@
+v20.0.0
+- Translations updates from Weblate
+- Changed test builds to 'Kodi 20 Nexus'
+- Increased version to 20.0.0
+  - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+    This done to know easier to which Kodi the addon works.
+
 v7.3.4
 - Update translation files
 


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.

A new branch for Nexus need to be added on this repo!

Are the version usages here and on the Matrix request OK for you?