### PR TITLE
Fix build for Windows ARM64.

### DIFF
--- a/lib/cppmyth/src/private/os/os.h
+++ b/lib/cppmyth/src/private/os/os.h
@@ -4,7 +4,7 @@
 #define NSROOT Myth
 #endif
 
-#if (defined(_WIN32) || defined(_WIN64))
+#if (defined(_WIN32) || defined(_WIN64) || defined(_M_ARM64))
 #include "windows/os-types.h"
 #else
 #include "unix/os-types.h"

--- a/lib/cppmyth/src/private/os/windows/msc_inttypes.h
+++ b/lib/cppmyth/src/private/os/windows/msc_inttypes.h
@@ -182,7 +182,7 @@ typedef struct {
 #define SCNdMAX     "I64d"
 #define SCNiMAX     "I64i"
 
-#ifdef _WIN64 // [
+#if (defined(_WIN64) || defined(_M_ARM64)) // [
 #  define SCNdPTR     "I64d"
 #  define SCNiPTR     "I64i"
 #else  // _WIN64 ][
@@ -248,7 +248,7 @@ typedef struct {
 #define SCNxMAX     "I64x"
 #define SCNXMAX     "I64X"
 
-#ifdef _WIN64 // [
+#if (defined(_WIN64) || defined(_M_ARM64)) // [
 #  define SCNoPTR     "I64o"
 #  define SCNuPTR     "I64u"
 #  define SCNxPTR     "I64x"

--- a/lib/cppmyth/src/private/os/windows/os-types.h
+++ b/lib/cppmyth/src/private/os/windows/os-types.h
@@ -42,7 +42,7 @@ typedef SOCKET net_socket_t;
 #endif
 
 #ifndef _SSIZE_T_DEFINED
-#ifdef  _WIN64
+#if (defined(_WIN64) || defined(_M_ARM64))
 typedef __int64    ssize_t;
 #else
 typedef _W64 int   ssize_t;

--- a/lib/cppmyth/src/private/os/windows/winpthreads.c
+++ b/lib/cppmyth/src/private/os/windows/winpthreads.c
@@ -498,6 +498,8 @@ int pthread_cancel(pthread_t t)
     GetThreadContext(t->h, &ctxt);
 #ifdef _M_X64
     ctxt.Rip = (uintptr_t) _pthread_invoke_cancel;
+#elif defined(_M_ARM64)
+    ctxt.Pc = (uintptr_t) _pthread_invoke_cancel; 
 #else
     ctxt.Eip = (uintptr_t) _pthread_invoke_cancel;
 #endif


### PR DESCRIPTION
Fix build of pvr.mythtv for Windows ARM64.
Tested with a MythTV 35 server and the latest Kodi built for Windows ARM64, plugin seems to work fine.